### PR TITLE
include thebelab javascript and css in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+recursive-include jupyter_sphinx/thebelab/*

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(
         'nbformat',
     ],
     python_requires = '>= 3.5',
+    package_data={'jupyter_sphinx': ['thebelab/*']},
 )


### PR DESCRIPTION
without these files thebelab does not work for documentation
built using installed versions of jupyter-sphinx

Closes #67.