### PR TITLE
Use math_block node directly instead of deprecated displaymath

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -64,7 +64,7 @@ can use variables and functions defined in cells earlier in the document:
     print('second cell: a = {}'.format(a))
 
 Because jupyter-sphinx uses the machinery of ``nbconvert``, it is capable of rendering
-much richer output than mere text; plots, for example:
+any rich output, for example plots:
 
 .. jupyter-execute::
 
@@ -77,6 +77,13 @@ much richer output than mere text; plots, for example:
     pyplot.plot(x, np.sin(x) / x)
     pyplot.plot(x, np.cos(x))
     pyplot.grid()
+
+LaTeX output:
+
+.. jupyter-execute::
+
+  from IPython.display import Latex
+  Latex('∫_{-∞}^∞ e^{-x²}dx = \sqrt{π}')
 
 or even full-blown javascript widgets:
 

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -11,11 +11,11 @@ from sphinx.util.fileutil import copy_asset
 from sphinx.transforms import SphinxTransform
 from sphinx.errors import ExtensionError
 from sphinx.addnodes import download_reference
-from sphinx.ext.mathbase import displaymath
 
 import docutils
 from IPython.lib.lexers import IPythonTracebackLexer, IPython3Lexer
 from docutils.parsers.rst import Directive, directives
+from docutils.nodes import math_block
 
 import nbconvert
 from nbconvert.preprocessors.execute import executenb
@@ -528,8 +528,8 @@ def cell_output_to_nodes(cell, data_priority, write_stderr, dir, thebe_config):
                     format='html'
                 ))
             elif mime_type == 'text/latex':
-                to_add.append(displaymath(
-                    latex=data,
+                to_add.append(math_block(
+                    text=data,
                     nowrap=False,
                     number=None,
                  ))


### PR DESCRIPTION
Also add a demonstration of latex math display to the docs.
Closes issue #77.