### PR TITLE
added linenos (line numbers) flag, updated docs, and basic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.tox/
 *.py[cod]
 
 # Packages

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -175,6 +175,24 @@ produces:
 
     print('this code is below the output')
 
+You may also add *line numbers* to the source code with ``:linenos:``::
+
+    .. jupyter-execute::
+        :linenos:
+
+        print('A')
+        print('B')
+        print('C')
+
+produces:
+
+.. jupyter-execute::
+    :linenos:
+
+    print('A')
+    print('B')
+    print('C')
+
 
 Controlling exceptions
 ----------------------

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -153,6 +153,7 @@ class JupyterCell(Directive):
         'hide-code': directives.flag,
         'hide-output': directives.flag,
         'code-below': directives.flag,
+        'linenos': directives.flag,
         'raises': csv_option,
         'stderr': directives.flag,
     }
@@ -187,6 +188,7 @@ class JupyterCell(Directive):
             hide_code=('hide-code' in self.options),
             hide_output=('hide-output' in self.options),
             code_below=('code-below' in self.options),
+            linenos=('linenos' in self.options),
             raises=self.options.get('raises'),
             stderr=('stderr' in self.options),
         )]
@@ -391,6 +393,12 @@ class ExecuteJupyterCells(SphinxTransform):
             for node in nodes:
                 source = node.children[0]
                 source.attributes['language'] = lexer
+
+            # Add line numbers
+            for node in nodes:
+                if node["linenos"]:
+                    source = node.children[0]
+                    source["linenos"] = True
 
             # Write certain cell outputs (e.g. images) to separate files, and
             # modify the metadata of the associated cells in 'notebook' to

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -68,6 +68,7 @@ def test_basic(doctree):
     assert cell.attributes['code_below'] is False
     assert cell.attributes['hide_code'] is False
     assert cell.attributes['hide_output'] is False
+    assert cell.attributes['linenos'] is False
     assert cell.children[0].rawsource.strip() == "2 + 2"
     assert cell.children[1].rawsource.strip() == "4"
 
@@ -112,6 +113,32 @@ def test_code_below(doctree):
     assert cell.attributes['code_below'] is True
     assert cell.children[0].rawsource.strip() == "4"
     assert cell.children[1].rawsource.strip() == "2 + 2"
+
+
+def test_linenos(doctree):
+    source = '''
+    .. jupyter-execute::
+        :linenos:
+
+        2 + 2
+    '''
+    tree = doctree(source)
+    cell, = tree.traverse(JupyterCellNode)
+    assert cell.attributes['linenos'] is True
+    assert len(cell.children) == 2
+    assert cell.children[0].rawsource.strip() == "2 + 2"
+    assert cell.children[1].rawsource.strip() == "4"
+    source = '''
+    .. jupyter-execute::
+        :linenos:
+        :code-below:
+
+        2 + 2
+    '''
+    tree = doctree(source)
+    cell, = tree.traverse(JupyterCellNode)
+    assert len(cell.children) == 2
+    assert cell.attributes['linenos'] is True
 
 
 def test_execution_environment_carries_over(doctree):


### PR DESCRIPTION
I added a ``:linenos:`` flag to add line numbers to the source code. One aim here is to distinguish code and output.

It looks a little weird in the Alabaster theme, as it cuts the lines length, but it looks pretty nice in readthedocs.  It generates a standard html table, so it could be CSS styled as one pleases.

It also shows up in LatexPDF.
