### PR TITLE
added continue_linenos directive, doc updates, and tests

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -193,6 +193,31 @@ produces:
     print('B')
     print('C')
 
+You may also *continue line numbers* from the previous cell with ``:continue_linenos:``::
+
+  .. jupyter-execute::
+      :linenos:
+
+      print('A')
+
+  .. jupyter-execute::
+      :continue_linenos:
+
+      print('B')
+      print('C')
+
+produces:
+
+.. jupyter-execute::
+    :linenos:
+
+    print('A')
+
+.. jupyter-execute::
+    :continue_linenos:
+
+    print('B')
+    print('C')
 
 Controlling exceptions
 ----------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -193,7 +193,7 @@ produces:
     print('B')
     print('C')
 
-You may also *continue line numbers* from the previous cell with ``:continue_linenos:``::
+You may also *continue line numbers* from the previous cell with ``:continue-linenos:``::
 
   .. jupyter-execute::
       :linenos:
@@ -201,7 +201,7 @@ You may also *continue line numbers* from the previous cell with ``:continue_lin
       print('A')
 
   .. jupyter-execute::
-      :continue_linenos:
+      :continue-linenos:
 
       print('B')
       print('C')
@@ -214,7 +214,7 @@ produces:
     print('A')
 
 .. jupyter-execute::
-    :continue_linenos:
+    :continue-linenos:
 
     print('B')
     print('C')

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -154,7 +154,7 @@ class JupyterCell(Directive):
         'hide-output': directives.flag,
         'code-below': directives.flag,
         'linenos': directives.flag,
-        'continue_linenos': directives.flag,
+        'continue-linenos': directives.flag,
         'raises': csv_option,
         'stderr': directives.flag,
     }
@@ -190,7 +190,7 @@ class JupyterCell(Directive):
             hide_output=('hide-output' in self.options),
             code_below=('code-below' in self.options),
             linenos=('linenos' in self.options),
-            continue_linenos=('continue_linenos' in self.options),
+            continue_linenos=('continue-linenos' in self.options),
             raises=self.options.get('raises'),
             stderr=('stderr' in self.options),
         )]
@@ -398,7 +398,7 @@ class ExecuteJupyterCells(SphinxTransform):
 
             # Add line numbers to code cells if linenos directive is set.
             # Continue line numbers from previous cell with line numbers
-            # if continue_linenos directive is set.
+            # if continue-linenos directive is set.
             linenostart = 1
             for node in nodes:
                 source = node.children[0]

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -410,7 +410,7 @@ class ExecuteJupyterCells(SphinxTransform):
                     source["linenos"] = True
                 # Advance linenostart or reset it
                 if node["continue_linenos"] or node["linenos"]:
-                    linenostart += len(source.rawsource.split("\n"))
+                    linenostart += source.rawsource.count("\n") + 1
                 else:
                     linenostart = 1
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -149,7 +149,7 @@ def test_continue_linenos(doctree):
         2 + 2
 
     .. jupyter-execute::
-        :continue_linenos:
+        :continue-linenos:
 
         3 + 3
     '''
@@ -162,7 +162,7 @@ def test_continue_linenos(doctree):
     assert 'highlight_args' not in cell0.children[0].attributes
     assert cell0.children[0].rawsource.strip() == "2 + 2"
     assert cell0.children[1].rawsource.strip() == "4"
-    # :continue_linenos:
+    # :continue-linenos:
     assert cell1.attributes['linenos'] is False
     assert cell1.attributes['continue_linenos']
     assert 'highlight_args' not in cell1.attributes
@@ -183,7 +183,7 @@ def test_continue_linenos(doctree):
         'cell1'  # should restart with line number 1
 
     .. jupyter-execute::
-        :continue_linenos:
+        :continue-linenos:
 
         'cell2'  # should be line number 2
 
@@ -192,12 +192,12 @@ def test_continue_linenos(doctree):
         'cell3' # no line number directive
 
     .. jupyter-execute::
-        :continue_linenos:
+        :continue-linenos:
 
         'cell4' # should restart at line number 1
 
     .. jupyter-execute::
-        :continue_linenos:
+        :continue-linenos:
 
         'cell5' # should continue with line number 2
     '''
@@ -211,16 +211,16 @@ def test_continue_linenos(doctree):
     # :linenos:
     assert cell1.children[0].attributes["linenos"]
     assert "highlight_args" not in cell1.children[0].attributes
-    # :continue_linenos:
+    # :continue-linenos:
     assert cell2.children[0].attributes["linenos"]
     assert cell2.children[0].attributes["highlight_args"]["linenostart"] == 2
     # (No line number directive)
     assert "linenos" not in cell3.children[0].attributes
     assert "highlight_args" not in cell3.children[0].attributes
-    # :continue_linenos:
+    # :continue-linenos:
     assert cell4.children[0].attributes["linenos"]
     assert cell4.children[0].attributes["highlight_args"]["linenostart"] == 1
-    # :continue_linenos:
+    # :continue-linenos:
     assert cell5.children[0].attributes["linenos"]
     assert cell5.children[0].attributes["highlight_args"]["linenostart"] == 2
 


### PR DESCRIPTION
This adds a :continue_linenos: directive that allows you to continue the previous cell's line numbers, i.e. if it is flagged with `linenos` or `continue_linenos`.

Any cells in between with the `hide_code` directive will not reset the line numbering.
If there is no previous line-numbered cell, it starts the line numbering at 1. 

I am finding it useful in documentation to show sections of related code, e.g. using the same variables, as restarting numbering from 1 in those cases looks odd.