### PR TITLE
Continue linenos through setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.tox/
 *.py[cod]
 
 # Packages

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -193,6 +193,31 @@ produces:
     print('B')
     print('C')
 
+You may also *continue line numbers* from the previous cell with ``:continue_linenos:``::
+
+  .. jupyter-execute::
+      :linenos:
+
+      print('A')
+
+  .. jupyter-execute::
+      :continue_linenos:
+
+      print('B')
+      print('C')
+
+produces:
+
+.. jupyter-execute::
+    :linenos:
+
+    print('A')
+
+.. jupyter-execute::
+    :continue_linenos:
+
+    print('B')
+    print('C')
 
 Controlling exceptions
 ----------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -330,11 +330,9 @@ jupyter_execute_kwargs
 
 jupyter_sphinx_linenos
 
-    Boolean argument it use line numbering in code cell display by default. Equivalent
-    to setting the `linenos` directive for all code cells.
+    Whether to show line numbering in all ``jupyter-execute`` sources.
 
 jupyter_sphinx_continue_linenos
 
-    Boolean argument to use line numbering in code cells and continue line numbering
-    from the previous cell. When set, line number can be reset to start at one by using
-    the directive `linenos`.
+    Whether to show continuous line numbering in all ``jupyter-execute`` sources.
+    Line numbering can be reset to one with a ``linenos`` directive.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -335,4 +335,3 @@ jupyter_sphinx_linenos
 jupyter_sphinx_continue_linenos
 
     Whether to show continuous line numbering in all ``jupyter-execute`` sources.
-    Line numbering can be reset to one with a ``linenos`` directive.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -175,6 +175,24 @@ produces:
 
     print('this code is below the output')
 
+You may also add *line numbers* to the source code with ``:linenos:``::
+
+    .. jupyter-execute::
+        :linenos:
+
+        print('A')
+        print('B')
+        print('C')
+
+produces:
+
+.. jupyter-execute::
+    :linenos:
+
+    print('A')
+    print('B')
+    print('C')
+
 
 Controlling exceptions
 ----------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -193,7 +193,7 @@ produces:
     print('B')
     print('C')
 
-You may also *continue line numbers* from the previous cell with ``:continue_linenos:``::
+You may also *continue line numbers* from the previous cell with ``:continue-linenos:``::
 
   .. jupyter-execute::
       :linenos:
@@ -201,7 +201,7 @@ You may also *continue line numbers* from the previous cell with ``:continue_lin
       print('A')
 
   .. jupyter-execute::
-      :continue_linenos:
+      :continue-linenos:
 
       print('B')
       print('C')
@@ -214,7 +214,7 @@ produces:
     print('A')
 
 .. jupyter-execute::
-    :continue_linenos:
+    :continue-linenos:
 
     print('B')
     print('C')

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -193,32 +193,6 @@ produces:
     print('B')
     print('C')
 
-You may also *continue line numbers* from the previous cell with ``:continue-linenos:``::
-
-  .. jupyter-execute::
-      :linenos:
-
-      print('A')
-
-  .. jupyter-execute::
-      :continue-linenos:
-
-      print('B')
-      print('C')
-
-produces:
-
-.. jupyter-execute::
-    :linenos:
-
-    print('A')
-
-.. jupyter-execute::
-    :continue-linenos:
-
-    print('B')
-    print('C')
-
 Controlling exceptions
 ----------------------
 
@@ -353,3 +327,14 @@ jupyter_execute_kwargs
 
     Keyword arguments to pass to ``nbconvert.preprocessors.execute.executenb``, which controls how
     code cells are executed. The default is ``dict(timeout=-1, allow_errors=True)``.
+
+jupyter_sphinx_linenos
+
+    Boolean argument it use line numbering in code cell display by default. Equivalent
+    to setting the `linenos` directive for all code cells.
+
+jupyter_sphinx_continue_linenos
+
+    Boolean argument to use line numbering in code cells and continue line numbering
+    from the previous cell. When set, line number can be reset to start at one by using
+    the directive `linenos`.

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -131,6 +131,8 @@ class JupyterCell(Directive):
         If provided, the cell output will not be displayed in the output.
     code-below : bool
         If provided, the code will be shown below the cell output.
+    linenos : bool
+        If provided, the code will be shown with line numbering.
     raises : comma separated list of exception types
         If provided, a comma-separated list of exception type names that
         the cell may raise. If one of the listed execption types is raised
@@ -154,7 +156,7 @@ class JupyterCell(Directive):
         'hide-output': directives.flag,
         'code-below': directives.flag,
         'linenos': directives.flag,
-        'continue-linenos': directives.flag,
+        # 'continue-linenos': directives.flag,   #<--- remove this
         'raises': csv_option,
         'stderr': directives.flag,
     }
@@ -190,7 +192,7 @@ class JupyterCell(Directive):
             hide_output=('hide-output' in self.options),
             code_below=('code-below' in self.options),
             linenos=('linenos' in self.options),
-            continue_linenos=('continue-linenos' in self.options),
+            # continue_linenos=('continue-linenos' in self.options),
             raises=self.options.get('raises'),
             stderr=('stderr' in self.options),
         )]
@@ -329,7 +331,8 @@ class ExecuteJupyterCells(SphinxTransform):
         default_kernel = self.config.jupyter_execute_default_kernel
         default_names = default_notebook_names(docname)
         thebe_config = self.config.jupyter_sphinx_thebelab_config
-
+        linenos_config = self.config.jupyter_sphinx_linenos
+        continue_linenos = self.config.jupyter_sphinx_continue_linenos
         # Check if we have anything to execute.
         if not doctree.traverse(JupyterCellNode):
             return
@@ -396,23 +399,24 @@ class ExecuteJupyterCells(SphinxTransform):
                 source = node.children[0]
                 source.attributes['language'] = lexer
 
-            # Add line numbers to code cells if linenos directive is set.
-            # Continue line numbers from previous cell with line numbers
-            # if continue-linenos directive is set.
+            # Add line numbers to code cells if jupyter_sphinx_linenos or
+            # jupyter_sphinx_continue_linenos are set in the configuration,
+            # or the linenos directive is set.
+            # Reset linenumber if linenos directive is set.
+            # Update current line numbers from cell if jupyter_sphinx_continue_linenos
+            # is set.
             linenostart = 1
             for node in nodes:
                 source = node.children[0]
-                if node["continue_linenos"]:
+                if linenos_config or continue_linenos:
+                    source["linenos"] = True
+                if node["linenos"]:
+                    linenostart = 1
+                    source["linenos"] = True
+                if continue_linenos:
                     source["linenos"] = True
                     source["highlight_args"] = {'linenostart': linenostart}
-                elif node["linenos"]:
-                    linenostart = 1
-                    source["linenos"] = True
-                # Advance linenostart or reset it
-                if node["continue_linenos"] or node["linenos"]:
                     linenostart += source.rawsource.count("\n") + 1
-                else:
-                    linenostart = 1
 
             # Write certain cell outputs (e.g. images) to separate files, and
             # modify the metadata of the associated cells in 'notebook' to
@@ -790,6 +794,10 @@ def setup(app):
     app.add_config_value('jupyter_sphinx_thebelab_config', None, 'html')
 
     app.add_config_value('jupyter_sphinx_thebelab_url', THEBELAB_URL_DEFAULT, 'html')
+
+    # linenos config
+    app.add_config_value('jupyter_sphinx_linenos', False, 'env')
+    app.add_config_value('jupyter_sphinx_continue_linenos', False, 'env')
 
     # Used for nodes that do not need to be rendered
     def skip(self, node):

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -154,7 +154,7 @@ class JupyterCell(Directive):
         'hide-output': directives.flag,
         'code-below': directives.flag,
         'linenos': directives.flag,
-        'continue_linenos': directives.flag,
+        'continue-linenos': directives.flag,
         'raises': csv_option,
         'stderr': directives.flag,
     }
@@ -190,7 +190,7 @@ class JupyterCell(Directive):
             hide_output=('hide-output' in self.options),
             code_below=('code-below' in self.options),
             linenos=('linenos' in self.options),
-            continue_linenos=('continue_linenos' in self.options),
+            continue_linenos=('continue-linenos' in self.options),
             raises=self.options.get('raises'),
             stderr=('stderr' in self.options),
         )]
@@ -398,7 +398,7 @@ class ExecuteJupyterCells(SphinxTransform):
 
             # Add line numbers to code cells if linenos directive is set.
             # Continue line numbers from previous cell with line numbers
-            # if continue_linenos directive is set.
+            # if continue-linenos directive is set.
             linenostart = 1
             for node in nodes:
                 source = node.children[0]

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -153,6 +153,7 @@ class JupyterCell(Directive):
         'hide-code': directives.flag,
         'hide-output': directives.flag,
         'code-below': directives.flag,
+        'linenos': directives.flag,
         'raises': csv_option,
         'stderr': directives.flag,
     }
@@ -187,6 +188,7 @@ class JupyterCell(Directive):
             hide_code=('hide-code' in self.options),
             hide_output=('hide-output' in self.options),
             code_below=('code-below' in self.options),
+            linenos=('linenos' in self.options),
             raises=self.options.get('raises'),
             stderr=('stderr' in self.options),
         )]
@@ -391,6 +393,12 @@ class ExecuteJupyterCells(SphinxTransform):
             for node in nodes:
                 source = node.children[0]
                 source.attributes['language'] = lexer
+
+            # Add line numbers
+            for node in nodes:
+                if node["linenos"]:
+                    source = node.children[0]
+                    source["linenos"] = True
 
             # Write certain cell outputs (e.g. images) to separate files, and
             # modify the metadata of the associated cells in 'notebook' to

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -410,7 +410,7 @@ class ExecuteJupyterCells(SphinxTransform):
                     source["linenos"] = True
                 # Advance linenostart or reset it
                 if node["continue_linenos"] or node["linenos"]:
-                    linenostart += len(source.rawsource.split("\n"))
+                    linenostart += source.rawsource.count("\n") + 1
                 else:
                     linenostart = 1
 

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -191,7 +191,6 @@ class JupyterCell(Directive):
             hide_output=('hide-output' in self.options),
             code_below=('code-below' in self.options),
             linenos=('linenos' in self.options),
-            # continue_linenos=('continue-linenos' in self.options),
             raises=self.options.get('raises'),
             stderr=('stderr' in self.options),
         )]

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -156,7 +156,6 @@ class JupyterCell(Directive):
         'hide-output': directives.flag,
         'code-below': directives.flag,
         'linenos': directives.flag,
-        # 'continue-linenos': directives.flag,   #<--- remove this
         'raises': csv_option,
         'stderr': directives.flag,
     }

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -400,19 +400,14 @@ class ExecuteJupyterCells(SphinxTransform):
             # Add line numbers to code cells if jupyter_sphinx_linenos or
             # jupyter_sphinx_continue_linenos are set in the configuration,
             # or the linenos directive is set.
-            # Reset linenumber if linenos directive is set.
             # Update current line numbers from cell if jupyter_sphinx_continue_linenos
             # is set.
             linenostart = 1
             for node in nodes:
                 source = node.children[0]
-                if linenos_config or continue_linenos:
-                    source["linenos"] = True
-                if node["linenos"]:
-                    linenostart = 1
+                if linenos_config or continue_linenos or node["linenos"]:
                     source["linenos"] = True
                 if continue_linenos:
-                    source["linenos"] = True
                     source["highlight_args"] = {'linenostart': linenostart}
                     linenostart += source.rawsource.count("\n") + 1
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -165,15 +165,10 @@ def test_continue_linenos_conf_option(doctree):
 
         3 + 3
 
-    .. jupyter-execute::
-        :linenos:
-
-        4 + 4
-
     '''
     continue_linenos_config = "jupyter_sphinx_continue_linenos = True"
     tree = doctree(source, config=continue_linenos_config)
-    cell0, cell1, cell2 = tree.traverse(JupyterCellNode)
+    cell0, cell1 = tree.traverse(JupyterCellNode)
     assert cell0.children[0].attributes['linenos']
     assert cell0.children[0].attributes['highlight_args']['linenostart'] == 1
     assert cell0.children[0].rawsource.strip() == "2 + 2"
@@ -183,6 +178,7 @@ def test_continue_linenos_conf_option(doctree):
     assert cell1.children[0].attributes['highlight_args']['linenostart'] == 2
     assert cell1.children[0].rawsource.strip() == "3 + 3"
     assert cell1.children[1].rawsource.strip() == "6"
+
 
 def test_execution_environment_carries_over(doctree):
     source = '''

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -68,6 +68,7 @@ def test_basic(doctree):
     assert cell.attributes['code_below'] is False
     assert cell.attributes['hide_code'] is False
     assert cell.attributes['hide_output'] is False
+    assert cell.attributes['linenos'] is False
     assert cell.children[0].rawsource.strip() == "2 + 2"
     assert cell.children[1].rawsource.strip() == "4"
 
@@ -112,6 +113,32 @@ def test_code_below(doctree):
     assert cell.attributes['code_below'] is True
     assert cell.children[0].rawsource.strip() == "4"
     assert cell.children[1].rawsource.strip() == "2 + 2"
+
+
+def test_linenos(doctree):
+    source = '''
+    .. jupyter-execute::
+        :linenos:
+
+        2 + 2
+    '''
+    tree = doctree(source)
+    cell, = tree.traverse(JupyterCellNode)
+    assert cell.attributes['linenos'] is True
+    assert len(cell.children) == 2
+    assert cell.children[0].rawsource.strip() == "2 + 2"
+    assert cell.children[1].rawsource.strip() == "4"
+    source = '''
+    .. jupyter-execute::
+        :linenos:
+        :code-below:
+
+        2 + 2
+    '''
+    tree = doctree(source)
+    cell, = tree.traverse(JupyterCellNode)
+    assert len(cell.children) == 2
+    assert cell.attributes['linenos'] is True
 
 
 def test_execution_environment_carries_over(doctree):

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -139,91 +139,58 @@ def test_linenos(doctree):
     cell, = tree.traverse(JupyterCellNode)
     assert len(cell.children) == 2
     assert cell.attributes['linenos'] is True
-#
-#
-# def test_continue_linenos(doctree):
-#     source = '''
-#     .. jupyter-execute::
-#         :linenos:
-#
-#         2 + 2
-#
-#     .. jupyter-execute::
-#         :continue-linenos:
-#
-#         3 + 3
-#     '''
-#     tree = doctree(source)
-#     (cell0, cell1) = tree.traverse(JupyterCellNode)
-#     # :linenos:
-#     assert cell0.attributes['linenos']
-#     assert cell0.attributes['continue_linenos'] is False
-#     assert cell0.children[0].attributes['linenos']
-#     assert 'highlight_args' not in cell0.children[0].attributes
-#     assert cell0.children[0].rawsource.strip() == "2 + 2"
-#     assert cell0.children[1].rawsource.strip() == "4"
-#     # :continue-linenos:
-#     assert cell1.attributes['linenos'] is False
-#     assert cell1.attributes['continue_linenos']
-#     assert 'highlight_args' not in cell1.attributes
-#     assert cell1.children[0].attributes['linenos']
-#     assert cell1.children[0].attributes['highlight_args']['linenostart'] == 2
-#     assert cell1.children[0].rawsource.strip() == "3 + 3"
-#     assert cell1.children[1].rawsource.strip() == "6"
-#
-#     source2 = '''
-#     .. jupyter-execute::
-#         :linenos:
-#
-#         'cell0'  # will be line number 1
-#
-#     .. jupyter-execute::
-#         :linenos:
-#
-#         'cell1'  # should restart with line number 1
-#
-#     .. jupyter-execute::
-#         :continue-linenos:
-#
-#         'cell2'  # should be line number 2
-#
-#     .. jupyter-execute::
-#
-#         'cell3' # no line number directive
-#
-#     .. jupyter-execute::
-#         :continue-linenos:
-#
-#         'cell4' # should restart at line number 1
-#
-#     .. jupyter-execute::
-#         :continue-linenos:
-#
-#         'cell5' # should continue with line number 2
-#     '''
-#     tree2 = doctree(source2)
-#     cells = tree2.traverse(JupyterCellNode)
-#     assert len(cells) == 6
-#     (cell0, cell1, cell2, cell3, cell4, cell5) = cells
-#     # :linenos:
-#     assert cell0.children[0].attributes["linenos"]
-#     assert "highlight_args" not in cell0.children[0].attributes
-#     # :linenos:
-#     assert cell1.children[0].attributes["linenos"]
-#     assert "highlight_args" not in cell1.children[0].attributes
-#     # :continue-linenos:
-#     assert cell2.children[0].attributes["linenos"]
-#     assert cell2.children[0].attributes["highlight_args"]["linenostart"] == 2
-#     # (No line number directive)
-#     assert "linenos" not in cell3.children[0].attributes
-#     assert "highlight_args" not in cell3.children[0].attributes
-#     # :continue-linenos:
-#     assert cell4.children[0].attributes["linenos"]
-#     assert cell4.children[0].attributes["highlight_args"]["linenostart"] == 1
-#     # :continue-linenos:
-#     assert cell5.children[0].attributes["linenos"]
-#     assert cell5.children[0].attributes["highlight_args"]["linenostart"] == 2
-#
+
+
+def test_linenos_conf_option(doctree):
+    source = '''
+    .. jupyter-execute::
+
+        2 + 2
+    '''
+    tree = doctree(source, config="jupyter_sphinx_linenos = True")
+    cell, = tree.traverse(JupyterCellNode)
+    assert cell.children[0].attributes['linenos']
+    assert 'highlight_args' not in cell.children[0].attributes
+    assert cell.children[0].rawsource.strip() == "2 + 2"
+    assert cell.children[1].rawsource.strip() == "4"
+
+
+def test_continue_linenos_conf_option(doctree):
+    source = '''
+    .. jupyter-execute::
+
+        2 + 2
+
+    .. jupyter-execute::
+
+        3 + 3
+
+    .. jupyter-execute::
+        :linenos:
+
+        4 + 4
+
+    '''
+    continue_linenos_config = "jupyter_sphinx_continue_linenos = True"
+    tree = doctree(source, config=continue_linenos_config)
+    cell0, cell1, cell2 = tree.traverse(JupyterCellNode)
+    assert cell0.children[0].attributes['linenos']
+    assert cell0.children[0].attributes['highlight_args']['linenostart'] == 1
+    assert cell0.children[0].rawsource.strip() == "2 + 2"
+    assert cell0.children[1].rawsource.strip() == "4"
+
+    assert cell1.children[0].attributes['linenos']
+    assert cell1.children[0].attributes['highlight_args']['linenostart'] == 2
+    assert cell1.children[0].rawsource.strip() == "3 + 3"
+    assert cell1.children[1].rawsource.strip() == "6"
+
+    # :linenos: directive should restart line numbering at one.
+    assert cell2.attributes['linenos']
+    assert cell2.children[0].attributes['linenos']
+    assert cell2.children[0].attributes['highlight_args']['linenostart'] == 1
+    assert cell2.children[0].rawsource.strip() == "4 + 4"
+    assert cell2.children[1].rawsource.strip() == "8"
+
 
 def test_execution_environment_carries_over(doctree):
     source = '''

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -149,7 +149,7 @@ def test_continue_linenos(doctree):
         2 + 2
 
     .. jupyter-execute::
-        :continue_linenos:
+        :continue-linenos:
 
         3 + 3
     '''
@@ -162,7 +162,7 @@ def test_continue_linenos(doctree):
     assert 'highlight_args' not in cell0.children[0].attributes
     assert cell0.children[0].rawsource.strip() == "2 + 2"
     assert cell0.children[1].rawsource.strip() == "4"
-    # :continue_linenos:
+    # :continue-linenos:
     assert cell1.attributes['linenos'] is False
     assert cell1.attributes['continue_linenos']
     assert 'highlight_args' not in cell1.attributes
@@ -183,7 +183,7 @@ def test_continue_linenos(doctree):
         'cell1'  # should restart with line number 1
 
     .. jupyter-execute::
-        :continue_linenos:
+        :continue-linenos:
 
         'cell2'  # should be line number 2
 
@@ -192,12 +192,12 @@ def test_continue_linenos(doctree):
         'cell3' # no line number directive
 
     .. jupyter-execute::
-        :continue_linenos:
+        :continue-linenos:
 
         'cell4' # should restart at line number 1
 
     .. jupyter-execute::
-        :continue_linenos:
+        :continue-linenos:
 
         'cell5' # should continue with line number 2
     '''
@@ -211,16 +211,16 @@ def test_continue_linenos(doctree):
     # :linenos:
     assert cell1.children[0].attributes["linenos"]
     assert "highlight_args" not in cell1.children[0].attributes
-    # :continue_linenos:
+    # :continue-linenos:
     assert cell2.children[0].attributes["linenos"]
     assert cell2.children[0].attributes["highlight_args"]["linenostart"] == 2
     # (No line number directive)
     assert "linenos" not in cell3.children[0].attributes
     assert "highlight_args" not in cell3.children[0].attributes
-    # :continue_linenos:
+    # :continue-linenos:
     assert cell4.children[0].attributes["linenos"]
     assert cell4.children[0].attributes["highlight_args"]["linenostart"] == 1
-    # :continue_linenos:
+    # :continue-linenos:
     assert cell5.children[0].attributes["linenos"]
     assert cell5.children[0].attributes["highlight_args"]["linenostart"] == 2
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -139,91 +139,91 @@ def test_linenos(doctree):
     cell, = tree.traverse(JupyterCellNode)
     assert len(cell.children) == 2
     assert cell.attributes['linenos'] is True
-
-
-def test_continue_linenos(doctree):
-    source = '''
-    .. jupyter-execute::
-        :linenos:
-
-        2 + 2
-
-    .. jupyter-execute::
-        :continue-linenos:
-
-        3 + 3
-    '''
-    tree = doctree(source)
-    (cell0, cell1) = tree.traverse(JupyterCellNode)
-    # :linenos:
-    assert cell0.attributes['linenos']
-    assert cell0.attributes['continue_linenos'] is False
-    assert cell0.children[0].attributes['linenos']
-    assert 'highlight_args' not in cell0.children[0].attributes
-    assert cell0.children[0].rawsource.strip() == "2 + 2"
-    assert cell0.children[1].rawsource.strip() == "4"
-    # :continue-linenos:
-    assert cell1.attributes['linenos'] is False
-    assert cell1.attributes['continue_linenos']
-    assert 'highlight_args' not in cell1.attributes
-    assert cell1.children[0].attributes['linenos']
-    assert cell1.children[0].attributes['highlight_args']['linenostart'] == 2
-    assert cell1.children[0].rawsource.strip() == "3 + 3"
-    assert cell1.children[1].rawsource.strip() == "6"
-
-    source2 = '''
-    .. jupyter-execute::
-        :linenos:
-
-        'cell0'  # will be line number 1
-
-    .. jupyter-execute::
-        :linenos:
-
-        'cell1'  # should restart with line number 1
-
-    .. jupyter-execute::
-        :continue-linenos:
-
-        'cell2'  # should be line number 2
-
-    .. jupyter-execute::
-
-        'cell3' # no line number directive
-
-    .. jupyter-execute::
-        :continue-linenos:
-
-        'cell4' # should restart at line number 1
-
-    .. jupyter-execute::
-        :continue-linenos:
-
-        'cell5' # should continue with line number 2
-    '''
-    tree2 = doctree(source2)
-    cells = tree2.traverse(JupyterCellNode)
-    assert len(cells) == 6
-    (cell0, cell1, cell2, cell3, cell4, cell5) = cells
-    # :linenos:
-    assert cell0.children[0].attributes["linenos"]
-    assert "highlight_args" not in cell0.children[0].attributes
-    # :linenos:
-    assert cell1.children[0].attributes["linenos"]
-    assert "highlight_args" not in cell1.children[0].attributes
-    # :continue-linenos:
-    assert cell2.children[0].attributes["linenos"]
-    assert cell2.children[0].attributes["highlight_args"]["linenostart"] == 2
-    # (No line number directive)
-    assert "linenos" not in cell3.children[0].attributes
-    assert "highlight_args" not in cell3.children[0].attributes
-    # :continue-linenos:
-    assert cell4.children[0].attributes["linenos"]
-    assert cell4.children[0].attributes["highlight_args"]["linenostart"] == 1
-    # :continue-linenos:
-    assert cell5.children[0].attributes["linenos"]
-    assert cell5.children[0].attributes["highlight_args"]["linenostart"] == 2
-
+#
+#
+# def test_continue_linenos(doctree):
+#     source = '''
+#     .. jupyter-execute::
+#         :linenos:
+#
+#         2 + 2
+#
+#     .. jupyter-execute::
+#         :continue-linenos:
+#
+#         3 + 3
+#     '''
+#     tree = doctree(source)
+#     (cell0, cell1) = tree.traverse(JupyterCellNode)
+#     # :linenos:
+#     assert cell0.attributes['linenos']
+#     assert cell0.attributes['continue_linenos'] is False
+#     assert cell0.children[0].attributes['linenos']
+#     assert 'highlight_args' not in cell0.children[0].attributes
+#     assert cell0.children[0].rawsource.strip() == "2 + 2"
+#     assert cell0.children[1].rawsource.strip() == "4"
+#     # :continue-linenos:
+#     assert cell1.attributes['linenos'] is False
+#     assert cell1.attributes['continue_linenos']
+#     assert 'highlight_args' not in cell1.attributes
+#     assert cell1.children[0].attributes['linenos']
+#     assert cell1.children[0].attributes['highlight_args']['linenostart'] == 2
+#     assert cell1.children[0].rawsource.strip() == "3 + 3"
+#     assert cell1.children[1].rawsource.strip() == "6"
+#
+#     source2 = '''
+#     .. jupyter-execute::
+#         :linenos:
+#
+#         'cell0'  # will be line number 1
+#
+#     .. jupyter-execute::
+#         :linenos:
+#
+#         'cell1'  # should restart with line number 1
+#
+#     .. jupyter-execute::
+#         :continue-linenos:
+#
+#         'cell2'  # should be line number 2
+#
+#     .. jupyter-execute::
+#
+#         'cell3' # no line number directive
+#
+#     .. jupyter-execute::
+#         :continue-linenos:
+#
+#         'cell4' # should restart at line number 1
+#
+#     .. jupyter-execute::
+#         :continue-linenos:
+#
+#         'cell5' # should continue with line number 2
+#     '''
+#     tree2 = doctree(source2)
+#     cells = tree2.traverse(JupyterCellNode)
+#     assert len(cells) == 6
+#     (cell0, cell1, cell2, cell3, cell4, cell5) = cells
+#     # :linenos:
+#     assert cell0.children[0].attributes["linenos"]
+#     assert "highlight_args" not in cell0.children[0].attributes
+#     # :linenos:
+#     assert cell1.children[0].attributes["linenos"]
+#     assert "highlight_args" not in cell1.children[0].attributes
+#     # :continue-linenos:
+#     assert cell2.children[0].attributes["linenos"]
+#     assert cell2.children[0].attributes["highlight_args"]["linenostart"] == 2
+#     # (No line number directive)
+#     assert "linenos" not in cell3.children[0].attributes
+#     assert "highlight_args" not in cell3.children[0].attributes
+#     # :continue-linenos:
+#     assert cell4.children[0].attributes["linenos"]
+#     assert cell4.children[0].attributes["highlight_args"]["linenostart"] == 1
+#     # :continue-linenos:
+#     assert cell5.children[0].attributes["linenos"]
+#     assert cell5.children[0].attributes["highlight_args"]["linenostart"] == 2
+#
 
 def test_execution_environment_carries_over(doctree):
     source = '''

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -184,14 +184,6 @@ def test_continue_linenos_conf_option(doctree):
     assert cell1.children[0].rawsource.strip() == "3 + 3"
     assert cell1.children[1].rawsource.strip() == "6"
 
-    # :linenos: directive should restart line numbering at one.
-    assert cell2.attributes['linenos']
-    assert cell2.children[0].attributes['linenos']
-    assert cell2.children[0].attributes['highlight_args']['linenostart'] == 1
-    assert cell2.children[0].rawsource.strip() == "4 + 4"
-    assert cell2.children[1].rawsource.strip() == "8"
-
-
 def test_execution_environment_carries_over(doctree):
     source = '''
     .. jupyter-execute::


### PR DESCRIPTION
Alternative to #82 . Adds `jupyter_sphinx_linenos` and `jupyter_sphinx_continue_linenos` settings. Both will turn on line numbering by default (equivalent to directive `:linenos:`). `jupyter_sphinx_continue_linenos` will continue the line number from the previous cell by default. The `linenos` directive can be used to restart line numbering at one. Updated docs.

Tests are insufficient.