### PR TITLE
Adds jupyter_sphinx_truncate_traceback option. Fixes #84.

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -328,3 +328,8 @@ jupyter_execute_kwargs
 
     Keyword arguments to pass to ``nbconvert.preprocessors.execute.executenb``, which controls how
     code cells are executed. The default is ``dict(timeout=-1, allow_errors=True)``.
+
+jupyter_sphinx_truncate_traceback
+
+    Whether to truncate trackback on a error, displaying only the first two lines
+    followed by an ellipsis.

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -367,3 +367,19 @@ def test_thebe_button_none(doctree):
     source = "No Jupyter cells"
     tree = doctree(source, config)
     assert len(tree.traverse(ThebeButtonNode)) == 0
+
+def test_truncate_traceback(doctree):
+    config = "jupyter_sphinx_truncate_traceback = True"
+    source = """
+    .. jupyter-execute::
+        :raises:
+
+        1/0"""
+    tree = doctree(source, config)
+    cell, = tree.traverse(JupyterCellNode)
+    output = cell.children[1]
+    assert output.rawsource == (
+        "---------------------------------------------------------------------------\n"
+        "ZeroDivisionError                         Traceback (most recent call last)\n"
+        "...\n"
+    )


### PR DESCRIPTION
Adds jupyter_sphinx_truncate_traceback option that truncates traceback to first two lines followed by an ellipsis, e.g.

```
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
...
```