### PR TITLE
Stab at adding stderr differentiation

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -1,0 +1,7 @@
+/*
+Custom CSS for stderr stream output.
+*/
+
+.stderr {
+    background-color: #FCC;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,3 +41,4 @@ jupyter_sphinx_thebelab_config = {
         "repo": "jupyter/jupyter-sphinx",
     },
 }
+html_static_path = ["_static/custom.css"]  # css overrides for Alabaster theme

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -252,9 +252,8 @@ produces:
     print("hello, world!", file=sys.stderr)
 
 .. note::
-  To `adjust the CSS <https://docs.readthedocs.io/en/stable/guides/adding-custom-css.html>`_
-  of the ``stderr`` stream, use the ``stderr`` class. If you are using the default
-  Sphinx theme, for example, add the following
+  To adjust the CSS of the ``stderr`` stream, use the ``stderr`` class. If you are using
+  the default Sphinx theme, for example, add the following
   `custom CSS <https://alabaster.readthedocs.io/en/latest/customization.html#custom-stylesheet>`_:
     ``.stderr {background-color: #FCC}``.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -255,7 +255,7 @@ produces:
   To adjust the CSS of the ``stderr`` stream, use the ``stderr`` class. If you are using
   the default Sphinx theme, for example, add the following
   `custom CSS <https://alabaster.readthedocs.io/en/latest/customization.html#custom-stylesheet>`_:
-    ``.stderr {background-color: #FCC}``.
+    ``.stderr {background-color: #FCC}``
 
 
 Controlling the execution environment

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -251,10 +251,13 @@ produces:
 
     print("hello, world!", file=sys.stderr)
 
-.. warning::
+.. note::
+  To `adjust the CSS <https://docs.readthedocs.io/en/stable/guides/adding-custom-css.html>`_
+  of the ``stderr`` stream, use the ``stderr`` class. If you are using the default
+  Sphinx theme, for example, add the following
+  `custom CSS <https://alabaster.readthedocs.io/en/latest/customization.html#custom-stylesheet>`_:
+    ``.stderr {background-color: #FCC}``.
 
-    Note that output written to ``stderr`` is not displayed any differently than output written
-    to ``stdout``.
 
 Controlling the execution environment
 -------------------------------------

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -520,16 +520,6 @@ def cell_output_to_nodes(cell, data_priority, write_stderr, dir, thebe_config):
                             classes=["error", "stderr"]
                     ))
                     to_add.append(container)
-
-                    # Alternative, without container
-
-                    # to_add.append(docutils.nodes.literal_block(
-                    #         text=output['text'],
-                    #         rawsource='', # disables Pygment highlighting
-                    #         language='none',
-                    #         classes=["error", "stderr"]
-                    # ))
-
             else:
                 to_add.append(docutils.nodes.literal_block(
                     text=output['text'],

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -494,13 +494,48 @@ def cell_output_to_nodes(cell, data_priority, write_stderr, dir, thebe_config):
         if (
             output_type == 'stream'
         ):
-            if not write_stderr and output["name"] == "stderr":
-                continue
-            to_add.append(docutils.nodes.literal_block(
-                text=output['text'],
-                rawsource=output['text'],
-                language='none',
-            ))
+            if output["name"] == "stderr":
+                if not write_stderr:
+                    continue
+                else:
+                    # Produce a container with an unhighlighted literal block for
+                    # `stderr` messages.
+                    #
+                    # Adds a "stderr" class that can be customized by the user for both
+                    # the container and the literal_block.
+                    #
+                    # Also adds "error" as a base class, which is fairly common
+                    # class in Sphinx themes. It should result in differenciation
+                    # from  stdout in most standard themes.
+                    #
+                    # Not setting "rawsource" disables Pygment hightlighting, which
+                    # would otherwise add a <div class="highlight"> to the container
+                    # that would hold the literal_block (<pre>).
+
+                    container = docutils.nodes.container(classes=["error", "stderr"])
+                    container.append(docutils.nodes.literal_block(
+                            text=output['text'],
+                            rawsource='',  # disables Pygment highlighting
+                            language='none',
+                            classes=["error", "stderr"]
+                    ))
+                    to_add.append(container)
+
+                    # Alternative, without container
+
+                    # to_add.append(docutils.nodes.literal_block(
+                    #         text=output['text'],
+                    #         rawsource='', # disables Pygment highlighting
+                    #         language='none',
+                    #         classes=["error", "stderr"]
+                    # ))
+
+            else:
+                to_add.append(docutils.nodes.literal_block(
+                    text=output['text'],
+                    rawsource=output['text'],
+                    language='none',
+                ))
         elif (
             output_type == 'error'
         ):

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -498,19 +498,18 @@ def cell_output_to_nodes(cell, data_priority, write_stderr, dir, thebe_config):
                 if not write_stderr:
                     continue
                 else:
-                    # Produce a container with an unhighlighted literal block for
+                    # Output a container with an unhighlighted literal block for
                     # `stderr` messages.
                     #
                     # Adds a "stderr" class that can be customized by the user for both
                     # the container and the literal_block.
                     #
-                    # Also adds "error" as a base class, which is fairly common
+                    # Also adds "error" as a base class, which is a fairly common
                     # class in Sphinx themes. It should result in differentiation
                     # from stdout in most Sphinx themes.
                     #
                     # Not setting "rawsource" disables Pygment hightlighting, which
-                    # would otherwise add a <div class="highlight"> to the container
-                    # that would hold the literal_block (<pre>).
+                    # would otherwise add a <div class="highlight">.
 
                     container = docutils.nodes.container(classes=["error", "stderr"])
                     container.append(docutils.nodes.literal_block(

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -505,8 +505,8 @@ def cell_output_to_nodes(cell, data_priority, write_stderr, dir, thebe_config):
                     # the container and the literal_block.
                     #
                     # Also adds "error" as a base class, which is fairly common
-                    # class in Sphinx themes. It should result in differenciation
-                    # from  stdout in most standard themes.
+                    # class in Sphinx themes. It should result in differentiation
+                    # from stdout in most Sphinx themes.
                     #
                     # Not setting "rawsource" disables Pygment hightlighting, which
                     # would otherwise add a <div class="highlight"> to the container

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -267,7 +267,9 @@ def test_stderr(doctree):
     tree = doctree(source)
     cell, = tree.traverse(JupyterCellNode)
     assert len(cell.children) == 2
-    assert cell.children[1].rawsource.strip() == "hello world"
+    assert 'stderr' in cell.children[1].attributes['classes']
+    assert 'error' in cell.children[1].attributes['classes']
+    assert cell.children[1].astext().strip() == "hello world"
 
 
 thebe_config = "jupyter_sphinx_thebelab_config = {\"dummy\": True}"


### PR DESCRIPTION
This attempts to add a separate output style for `stderr`, addressing #71. 

It adds a `literal_block` without highlighting (by not settings `rawsource` in `literal_block()`, which disables Pygment), inside a `container`. Both are set to classes `error` and `stderr`. `Error` is common in Sphinx themes, especially as a `div` (container) style, whereas `stderr`, applied after, is not, and will allow CSS customization by the user for this particular output.

The HTML result is the following:
```
<div class="error stderr docutils container">
<pre class="error stderr literal-block">{{ ERROR MESSAGE}}
</pre>
</div>
```

LatexPDF results are differentiated by the absence of borders. Tested in Alabaster and sphinx_rtd_theme. 