### PR TITLE
fix for CSS overflow error in code cell

### DIFF
--- a/jupyter_sphinx/css/jupyter-sphinx.css
+++ b/jupyter_sphinx/css/jupyter-sphinx.css
@@ -38,6 +38,7 @@ div.jupyter_container {
   border-radius: 2px;
   background-color: #f7f7f7;
   margin: 0 0;
+  overflow: auto;
 }
 
 .jupyter_container div.code_cell pre {


### PR DESCRIPTION
This fixes a CSS overflow error for the code cell when there are line numbers. Missed this one earlier!
