### PR TITLE
Fix sphinx_rtd_theme spacing

### DIFF
--- a/jupyter_sphinx/css/jupyter-sphinx.css
+++ b/jupyter_sphinx/css/jupyter-sphinx.css
@@ -109,6 +109,6 @@ div.jupyter_container + div.jupyter_container {
 }
 
 /* Fix for sphinx_rtd_theme spacing after jupyter_container #91 */
-.rst-content .jupyter_container + p {
-  margin-top: 24px;
+.rst-content .jupyter_container {
+    margin: 0 0 24px 0;
 }

--- a/jupyter_sphinx/css/jupyter-sphinx.css
+++ b/jupyter_sphinx/css/jupyter-sphinx.css
@@ -105,5 +105,10 @@ div.jupyter_container * {
 /* combine sequential jupyter cells,
    by moving sequential ones up higher on y-axis */
 div.jupyter_container + div.jupyter_container {
-    margin: -.5em 0 .4em 0; 
+    margin: -.5em 0 .4em 0;
+}
+
+/* Fix for sphinx_rtd_theme spacing after jupyter_container #91 */
+.rst-content .jupyter_container + p {
+  margin-top: 24px;
 }


### PR DESCRIPTION
Fix for #91. Identifies sphinx_rtd_theme in CSS via the .rst-content div and overrides margins of jupyter_container to match sphix_rtd_theme spacing.