### PR TITLE
Add emphasize-lines option

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -193,6 +193,32 @@ produces:
     print('B')
     print('C')
 
+You may also emphasize particular lines in the source code with ``:emphasize-lines:``::
+
+    .. jupyter-execute::
+        :emphasize-lines: 2,5-6
+
+        d = {
+            'a': 1,
+            'b': 2,
+            'c': 3,
+            'd': 4,
+            'e': 5,
+        }
+
+produces:
+
+.. jupyter-execute::
+    :emphasize-lines: 2,5-6
+
+    d = {
+        'a': 1,
+        'b': 2,
+        'c': 3,
+        'd': 4,
+        'e': 5,
+    }
+
 Controlling exceptions
 ----------------------
 

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -416,11 +416,8 @@ class ExecuteJupyterCells(SphinxTransform):
 
                 if linenos_config or continue_linenos or node["linenos"]:
                     source["linenos"] = True
-
-                highlight_args = source['highlight_args'] = {}
-
                 if continue_linenos:
-                    highlight_args['linenostart'] = linenostart
+                    source['highlight_args'] = {'linenostart': linenostart}
                     linenostart += nlines
 
                 emphasize_linespec = node['emphasize_lines']
@@ -431,6 +428,7 @@ class ExecuteJupyterCells(SphinxTransform):
                             'Line number spec is out of range(1-{}): {}'.format(
                                 nlines, emphasize_linespec), location=node['_location'])
                     hl_lines = [i + 1 for i in hl_lines if i < nlines]
+                    highlight_args = source.setdefault('highlight_args', {})
                     highlight_args['hl_lines'] = hl_lines
 
             # Add code cell CSS class

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -187,6 +187,8 @@ class JupyterCell(Directive):
             self.assert_has_content()
             content = self.content
 
+        # The code fragment is taken from CodeBlock directive almost unchanged:
+        # https://github.com/sphinx-doc/sphinx/blob/0319faf8f1503453b6ce19020819a8cf44e39f13/sphinx/directives/code.py#L134-L148
         emphasize_linespec = self.options.get('emphasize-lines')
         if emphasize_linespec:
             try:

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -180,6 +180,22 @@ def test_continue_linenos_conf_option(doctree):
     assert cell1.children[1].rawsource.strip() == "6"
 
 
+def test_emphasize_lines(doctree):
+    source = '''
+    .. jupyter-execute::
+        :emphasize-lines: 1,3-5
+
+        1 + 1
+        2 + 2
+        3 + 3
+        4 + 4
+        5 + 5
+    '''
+    tree = doctree(source)
+    cell, = tree.traverse(JupyterCellNode)
+    assert cell.attributes['emphasize_lines'] == '1,3-5'
+
+
 def test_execution_environment_carries_over(doctree):
     source = '''
     .. jupyter-execute::

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -190,10 +190,21 @@ def test_emphasize_lines(doctree):
         3 + 3
         4 + 4
         5 + 5
+    
+    .. jupyter-execute::
+        :emphasize-lines: 2, 4
+
+        1 + 1
+        2 + 2
+        3 + 3
+        4 + 4
+        5 + 5
     '''
     tree = doctree(source)
-    cell, = tree.traverse(JupyterCellNode)
-    assert cell.attributes['emphasize_lines'] == '1,3-5'
+    cell0, cell1 = tree.traverse(JupyterCellNode)
+
+    assert cell0.attributes['emphasize_lines'] == [1, 3, 4, 5]
+    assert cell1.attributes['emphasize_lines'] == [2, 4]
 
 
 def test_execution_environment_carries_over(doctree):


### PR DESCRIPTION
This PR adds `:emphasize-lines:` option to `sphinx-execute` directive. This option allows you to highlight specified lines in source code just like in `code-block` [directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive:option-code-block-emphasize-lines).

For example:
```
.. jupyter-execute::
    :linenos:
    :emphasize-lines: 2,5-6

    d = {
        'a': 1,
        'b': 2,
        'c': 3,
        'd': 4,
        'e': 5,
    }
```
produces:
![2020-01-04_05-21-01](https://user-images.githubusercontent.com/1299189/71758544-10d9ff80-2eb2-11ea-91bb-1ffed210cd1f.png)
