### PR TITLE
Fix for #110 and added :lineno-start: directive

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -177,17 +177,37 @@ produces:
 
 You may also add *line numbers* to the source code with ``:linenos:``::
 
-    .. jupyter-execute::
-        :linenos:
+  .. jupyter-execute::
+     :linenos:
 
-        print('A')
-        print('B')
-        print('C')
+     print('A')
+     print('B')
+     print('C')
 
 produces:
 
 .. jupyter-execute::
     :linenos:
+
+    print('A')
+    print('B')
+    print('C')
+
+
+To add *line numbers from a specific line* to the source code, use the
+``lineno-start`` directive::
+
+  .. jupyter-execute::
+     :lineno-start: 7
+
+     print('A')
+     print('B')
+     print('C')
+
+produces:
+
+.. jupyter-execute::
+    :lineno-start: 7
 
     print('A')
     print('B')
@@ -379,4 +399,5 @@ jupyter_sphinx_linenos
 
 jupyter_sphinx_continue_linenos
 
-    Whether to show continuous line numbering in all ``jupyter-execute`` sources.
+    Whether to continue line numbering from previous cell in all ``jupyter-execute``
+    sources.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -215,7 +215,6 @@ produces:
 You may also emphasize particular lines in the source code with ``:emphasize-lines:``::
 
     .. jupyter-execute::
-        :lineno-start: 2
         :emphasize-lines: 2,5-6
 
         d = {

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -193,7 +193,6 @@ produces:
     print('B')
     print('C')
 
-
 To add *line numbers from a specific line* to the source code, use the
 ``lineno-start`` directive::
 
@@ -216,6 +215,7 @@ produces:
 You may also emphasize particular lines in the source code with ``:emphasize-lines:``::
 
     .. jupyter-execute::
+        :lineno-start: 2
         :emphasize-lines: 2,5-6
 
         d = {
@@ -229,6 +229,7 @@ You may also emphasize particular lines in the source code with ``:emphasize-lin
 produces:
 
 .. jupyter-execute::
+    :lineno-start: 2
     :emphasize-lines: 2,5-6
 
     d = {

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -45,6 +45,9 @@ class JupyterCell(Directive):
         If provided, the code will be shown below the cell output.
     linenos : bool
         If provided, the code will be shown with line numbering.
+    lineno-start: nonnegative int
+        If provided, the code will be show with line numbering beginning from
+        specified line.
     emphasize-lines : comma separated list of line numbers
         If provided, the specified lines will be highlighted.
     raises : comma separated list of exception types
@@ -70,6 +73,7 @@ class JupyterCell(Directive):
         "hide-output": directives.flag,
         "code-below": directives.flag,
         "linenos": directives.flag,
+        "lineno-start": directives.nonnegative_int,
         "emphasize-lines": directives.unchanged_required,
         "raises": csv_option,
         "stderr": directives.flag,
@@ -78,6 +82,7 @@ class JupyterCell(Directive):
     def run(self):
         # This only works lazily because the logger is inited by Sphinx
         from . import logger
+
         location = self.state_machine.get_source_and_line(self.lineno)
 
         if self.arguments:
@@ -103,6 +108,7 @@ class JupyterCell(Directive):
 
         # The code fragment is taken from CodeBlock directive almost unchanged:
         # https://github.com/sphinx-doc/sphinx/blob/0319faf8f1503453b6ce19020819a8cf44e39f13/sphinx/directives/code.py#L134-L148
+
         emphasize_linespec = self.options.get("emphasize-lines")
         if emphasize_linespec:
             try:
@@ -129,6 +135,7 @@ class JupyterCell(Directive):
                 hide_output=("hide-output" in self.options),
                 code_below=("code-below" in self.options),
                 linenos=("linenos" in self.options),
+                linenostart=(self.options.get("lineno-start")),
                 emphasize_lines=hl_lines,
                 raises=self.options.get("raises"),
                 stderr=("stderr" in self.options),

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -171,20 +171,25 @@ class ExecuteJupyterCells(SphinxTransform):
                 source = node.children[0]
                 source.attributes["language"] = lexer
 
-            # Add line numbers to code cells if jupyter_sphinx_linenos or
-            # jupyter_sphinx_continue_linenos are set in the configuration,
-            # or the linenos directive is set.
-            # Update current line numbers from cell if jupyter_sphinx_continue_linenos
-            # is set.
+            # Add line numbering
+
             linenostart = 1
+
             for node in nodes:
                 source = node.children[0]
                 nlines = source.rawsource.count("\n") + 1
+                show_numbering = (
+                    linenos_config or node["linenos"] or node["linenostart"]
+                )
 
-                if linenos_config or continue_linenos or node["linenos"]:
+                if show_numbering:
                     source["linenos"] = True
-                if continue_linenos:
-                    source["highlight_args"] = {"linenostart": linenostart}
+                    if node["linenostart"]:
+                        linenostart = node["linenostart"]
+                    if node["linenostart"] or continue_linenos:
+                        source["highlight_args"] = {"linenostart": linenostart}
+                    else:
+                        linenostart = 1
                     linenostart += nlines
 
                 hl_lines = node["emphasize_lines"]
@@ -275,6 +280,7 @@ def setup(app):
     """
     # To avoid circular imports we'll lazily import
     from . import setup as jssetup
+
     js.logger.warning(
         (
             "`jupyter-sphinx` was initialized with the "


### PR DESCRIPTION
Adds :lineno-start: directive and turns off line numbering if continuous line numbering is set.