### PR TITLE
adding github action to publish to pypi

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: continuous-integration
+
+on: [push, pull_request]
+
+jobs:
+
+  publish:
+
+    name: Publish to PyPi
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Build package
+        run: |
+          pip install wheel
+          python setup.py sdist bdist_wheel
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.1.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_KEY }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,35 @@
+# Release instructions for jupyter-sphinx
+
+Jupyter Sphinx uses a GitHub action to automatically push a new release to
+PyPI when a GitHub release is added.
+
+To cut a new Jupyter Sphinx release, follow these steps:
+
+* Ensure that all tests are passing on master.
+* In [`_version.py`](https://github.com/jupyter/jupyter-sphinx/blob/master/jupyter_sphinx/_version.py),
+  change the "release type" section to "final" e.g.:
+
+  ```python
+  version_info = (0, 2, 3, "final")
+  ```
+* Make a release commit and push to master
+
+  ```
+  git add jupyter_sphinx/_version.py
+  git commit -m "RLS: 0.2.3"
+  git push upstream master
+  ```
+* [Create a new github release](https://github.com/jupyter/jupyter-sphinx/releases/new).
+  The target should be **master**, the tag and the title should be the version number,
+  e.g. `0.2.3`.
+* Creating the release in GitHub will push a tag commit to the repository, which will
+  trigger [a GitHub action](https://github.com/jupyter/jupyter-sphinx/blob/master/.github/workflows/artifacts.yml)
+  to build `jupyter-sphinx` and push the new version to PyPI.
+  [Confirm that the version has been bumped](https://pypi.org/project/jupyter-sphinx/).
+* In [`_version.py`](https://github.com/jupyter/jupyter-sphinx/blob/master/jupyter_sphinx/_version.py),
+  bump the minor version and change the "release type" section to "alpha" e.g.:
+
+  ```python
+  version_info = (0, 2, 4, "alpha")
+  ```
+* That's it!


### PR DESCRIPTION
This is a lightweight github action to publish a repository to PyPI when a new tag is pushed by cutting a release on GitHub. It also adds instructions to follow when cutting a release

It will be hard to test until we actually cut a new release, so maybe we should just try it and see how it goes? What do you think @akhmerov ?

Note: I am also happy to move tests from Travis to GitHub actions, which would standardize the infra a bit more, but only if y'all think it's a good idea