### PR TITLE
Handle missing notebook metadata `file_extension`

### DIFF
--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -257,15 +257,14 @@ def write_notebook_output(notebook, output_dir, notebook_name):
         os.path.join(output_dir, notebook_name + ".ipynb"),
     )
     # Write a script too.
-    if ntbk.metadata.get("language_info", {}).get("file_extension", None) is None:
+    ext = notebook.metadata.get("language_info", {}).get("file_extension", None)
+    if ext is None:
         ext = ".txt"
         js.logger.warning(
             "Notebook code has no file extension metadata, " "defaulting to `.txt`",
             # TODO correct location
             # location=document.settings.env.docname,
         )
-    else:
-        ext = notebook.metadata.language_info.file_extension
     contents = "\n\n".join(cell.source for cell in notebook.cells)
     with open(os.path.join(output_dir, notebook_name + ext), "w") as f:
         f.write(contents)

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -206,7 +206,7 @@ class ExecuteJupyterCells(SphinxTransform):
             # Write certain cell outputs (e.g. images) to separate files, and
             # modify the metadata of the associated cells in 'notebook' to
             # include the path to the output file.
-            write_notebook_output(notebook, output_dir, file_name)
+            write_notebook_output(notebook, output_dir, file_name, self.env.docname)
 
             try:
                 cm_language = notebook.metadata.language_info.codemirror_mode.name
@@ -239,7 +239,7 @@ def execute_cells(kernel_name, cells, execute_kwargs):
     return notebook
 
 
-def write_notebook_output(notebook, output_dir, notebook_name):
+def write_notebook_output(notebook, output_dir, notebook_name, location=None):
     """Extract output from notebook cells and write to files in output_dir.
 
     This also modifies 'notebook' in-place, adding metadata to each cell that
@@ -263,8 +263,7 @@ def write_notebook_output(notebook, output_dir, notebook_name):
         ext = ".txt"
         js.logger.warning(
             "Notebook code has no file extension metadata, " "defaulting to `.txt`",
-            # TODO correct location
-            # location=document.settings.env.docname,
+            location=location,
         )
     contents = "\n\n".join(cell.source for cell in notebook.cells)
     with open(os.path.join(output_dir, notebook_name + ext), "w",

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -257,7 +257,15 @@ def write_notebook_output(notebook, output_dir, notebook_name):
         os.path.join(output_dir, notebook_name + ".ipynb"),
     )
     # Write a script too.
-    ext = notebook.metadata.language_info.file_extension
+    if ntbk.metadata.get("language_info", {}).get("file_extension", None) is None:
+        ext = ".txt"
+        js.logger.warning(
+            "Notebook code has no file extension metadata, " "defaulting to `.txt`",
+            # TODO correct location
+            # location=document.settings.env.docname,
+        )
+    else:
+        ext = notebook.metadata.language_info.file_extension
     contents = "\n\n".join(cell.source for cell in notebook.cells)
     with open(os.path.join(output_dir, notebook_name + ext), "w") as f:
         f.write(contents)


### PR DESCRIPTION
The `file_extension` metadata is added to the notebook by the kernel, during execution.
This means that, in cases where the notebook has failed to execute, this line can raise an exception and kill the whole build, for example executablebooks/MyST-NB#175.
If this happens, we would like this line to fail gracefully; either by just not dumping the script file or (as proposed here) defaulting to a specific extension.