### PR TITLE
adding inline functionality to nodes function

### DIFF
--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -252,7 +252,7 @@ def cell_output_to_nodes(outputs, data_priority, write_stderr, dir,
         Each output, converted into a docutils node.
     """
     # If we're in `inline` mode, ensure that we don't add block-level nodes
-    if inline is True:
+    if inline:
         literal_node = docutils.nodes.literal
         math_node = docutils.nodes.math
     else:
@@ -282,7 +282,7 @@ def cell_output_to_nodes(outputs, data_priority, write_stderr, dir,
                         language="none",
                         classes=["stderr"],
                     )
-                    if inline is True:
+                    if inline:
                         # In this case, we don't wrap the text in containers
                         to_add.append(literal)
                     else:


### PR DESCRIPTION
This is a first pass at upstreaming the inline nodes functionality from myst-nb. Definitely might be some bugs in there, I just tried comparing the code between this and https://github.com/executablebooks/MyST-NB/blob/master/myst_nb/transform.py#L71 to make sure that it accomplished the same.

Also updated a test so that we try out this functionality.

cc @chrisjsewell does this seem correct to you?

closes https://github.com/jupyter/jupyter-sphinx/issues/123