### PR TITLE
Allow adding raw inputs and outputs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -305,6 +305,43 @@ produces:
 
     print("hello, world!", file=sys.stderr)
 
+Advanced usage: manually forming Jupyter cells
+----------------------------------------------
+
+When showing code samples that are computationally expensive, access restricted resources, or have non-deterministic output, it can be preferable to not have them run every time you build. You can simply embed input code without executing it using the ``jupyter-input`` directive expected output with ``jupyter-output``::
+
+  .. jupyter-input::
+      :linenos:
+
+      import time
+
+      def slow_print(str):
+          time.sleep(4000)    # Simulate an expensive process
+          print(str)
+    
+      slow_print("hello, world!")
+
+  .. jupyter-output::
+
+      hello, world!
+
+produces:
+
+.. jupyter-input::
+    :linenos:
+
+    import time
+
+    def slow_print(str):
+        time.sleep(4000)    # Simulate an expensive process
+        print(str)
+
+    slow_print("hello, world!")
+
+.. jupyter-output::
+
+    hello, world!
+
 Controlling the execution environment
 -------------------------------------
 The execution environment can be controlled by using the ``jupyter-kernel`` directive. This directive takes

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -317,8 +317,8 @@ produces:
 
     print("hello, world!", file=sys.stderr)
 
-Advanced usage: manually forming Jupyter cells
-----------------------------------------------
+Manually forming Jupyter cells
+------------------------------
 
 When showing code samples that are computationally expensive, access restricted resources, or have non-deterministic output, it can be preferable to not have them run every time you build. You can simply embed input code without executing it using the ``jupyter-input`` directive expected output with ``jupyter-output``::
 

--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -13,7 +13,9 @@ from pathlib import Path
 from .ast import (
     JupyterCell,
     JupyterCellNode,
+    InputCell,
     CellInputNode,
+    OutputCell,
     CellOutputNode,
     CellOutputBundleNode,
     JupyterKernelNode,
@@ -267,6 +269,8 @@ def setup(app):
 
     app.add_directive("jupyter-execute", JupyterCell)
     app.add_directive("jupyter-kernel", JupyterKernel)
+    app.add_directive("jupyter-input", InputCell)
+    app.add_directive("jupyter-output", OutputCell)
     app.add_directive("thebe-button", ThebeButton)
     app.add_role("jupyter-download:notebook", JupyterDownloadRole())
     app.add_role("jupyter-download:nb", JupyterDownloadRole())

--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -23,6 +23,7 @@ from .ast import (
     JupyterWidgetStateNode,
     WIDGET_VIEW_MIMETYPE,
     JupyterDownloadRole,
+    CombineCellInputOutput,
     CellOutputsToNodes,
 )
 from .execute import JupyterKernel, ExecuteJupyterCells
@@ -275,6 +276,7 @@ def setup(app):
     app.add_role("jupyter-download:notebook", JupyterDownloadRole())
     app.add_role("jupyter-download:nb", JupyterDownloadRole())
     app.add_role("jupyter-download:script", JupyterDownloadRole())
+    app.add_transform(CombineCellInputOutput)
     app.add_transform(ExecuteJupyterCells)
     app.add_transform(CellOutputsToNodes)
 

--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -13,9 +13,9 @@ from pathlib import Path
 from .ast import (
     JupyterCell,
     JupyterCellNode,
-    InputCell,
+    CellInput,
     CellInputNode,
-    OutputCell,
+    CellOutput,
     CellOutputNode,
     CellOutputBundleNode,
     JupyterKernelNode,
@@ -269,8 +269,8 @@ def setup(app):
 
     app.add_directive("jupyter-execute", JupyterCell)
     app.add_directive("jupyter-kernel", JupyterKernel)
-    app.add_directive("jupyter-input", InputCell)
-    app.add_directive("jupyter-output", OutputCell)
+    app.add_directive("jupyter-input", CellInput)
+    app.add_directive("jupyter-output", CellOutput)
     app.add_directive("thebe-button", ThebeButton)
     app.add_role("jupyter-download:notebook", JupyterDownloadRole())
     app.add_role("jupyter-download:nb", JupyterDownloadRole())

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -163,7 +163,7 @@ class JupyterCell(Directive):
         cell_node += cell_input
         return [cell_node]
 
-class InputCell(Directive):
+class CellInput(Directive):
     """Define a code cell to be included verbatim but not executed.
 
     Arguments
@@ -233,7 +233,7 @@ class InputCell(Directive):
         cell_node += cell_input
         return [cell_node]
 
-class OutputCell(Directive):
+class CellOutput(Directive):
     """Define an output cell to be included verbatim.
 
     Arguments

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -147,6 +147,8 @@ class ExecuteJupyterCells(SphinxTransform):
                 kernel_name = default_kernel
                 file_name = next(default_names)
 
+            # Add empty placeholder cells for non-executed nodes so nodes and cells can be zipped
+            # and the provided input/output can be inserted later
             notebook = execute_cells(
                 kernel_name,
                 [nbformat.v4.new_code_cell(node.astext() if node["execute"] else "") for node in nodes],
@@ -185,6 +187,7 @@ class ExecuteJupyterCells(SphinxTransform):
                         "Cell printed to stderr:\n{}".format(stderr[0]["text"])
                     )
 
+            # Insert input/output into placeholders for non-executed cells
             for node, cell in zip(nodes, notebook.cells):
                 if not node["execute"]:
                     cell.source = node.children[0].astext()

--- a/jupyter_sphinx/thebelab.py
+++ b/jupyter_sphinx/thebelab.py
@@ -1,5 +1,4 @@
 """Inserting interactive links with Thebelab."""
-import os
 import json
 import docutils
 from docutils.parsers.rst import Directive

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -682,14 +682,28 @@ def test_input_cell_linenos(doctree):
 
 def test_output_cell(doctree):
     source = """
+    .. jupyter-input::
+
+        3 + 2
+
     .. jupyter-output::
 
         4
     """
     tree = doctree(source)
     (cell,) = tree.traverse(JupyterCellNode)
-    (celloutput,) = cell.children
+    (cellinput, celloutput,) = cell.children
+    assert cellinput.children[0].rawsource.strip() == "3 + 2"
     assert celloutput.children[0].rawsource.strip() == "4"
+
+def test_output_only_error(doctree):
+    source = """
+    .. jupyter-output::
+
+        4
+    """
+    with pytest.raises(ExtensionError):
+        tree = doctree(source)
 
 def test_multiple_directives(doctree):
     source = """
@@ -706,11 +720,10 @@ def test_multiple_directives(doctree):
         5
     """
     tree = doctree(source)
-    (ex, jin, jout) = tree.traverse(JupyterCellNode)
+    (ex, jin) = tree.traverse(JupyterCellNode)
     (ex_in, ex_out) = ex.children
-    (jin_in, _) = jin.children
-    (jout_out,) = jout.children
+    (jin_in, jin_out) = jin.children
     assert ex_in.children[0].rawsource.strip() == "2 + 2"
     assert ex_out.children[0].rawsource.strip() == "4"
     assert jin_in.children[0].rawsource.strip() == "3 + 3"
-    assert jout_out.children[0].rawsource.strip() == "5"
+    assert jin_out.children[0].rawsource.strip() == "5"

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -654,3 +654,63 @@ def test_bash_kernel(doctree):
     outdir = Path(app.outdir)
     saved_text = (outdir / '../jupyter_execute/test.sh').read_text()
     assert 'echo "foo"' in saved_text
+
+def test_input_cell(doctree):
+    source = """
+    .. jupyter-input::
+
+        2 + 2
+    """
+    tree = doctree(source)
+    (cell,) = tree.traverse(JupyterCellNode)
+    (cellinput, _) = cell.children
+    assert cellinput.children[0].attributes["linenos"] is False
+    assert cellinput.children[0].rawsource.strip() == "2 + 2"
+
+def test_input_cell_linenos(doctree):
+    source = """
+    .. jupyter-input::
+        :linenos:
+
+        2 + 2
+    """
+    tree = doctree(source)
+    (cell,) = tree.traverse(JupyterCellNode)
+    (cellinput, _) = cell.children
+    assert cellinput.children[0].attributes["linenos"] is True
+    assert cellinput.children[0].rawsource.strip() == "2 + 2"
+
+def test_output_cell(doctree):
+    source = """
+    .. jupyter-output::
+
+        4
+    """
+    tree = doctree(source)
+    (cell,) = tree.traverse(JupyterCellNode)
+    (celloutput,) = cell.children
+    assert celloutput.children[0].rawsource.strip() == "4"
+
+def test_multiple_directives(doctree):
+    source = """
+    .. jupyter-execute::
+
+        2 + 2
+    
+    .. jupyter-input::
+    
+        3 + 3
+    
+    .. jupyter-output::
+
+        5
+    """
+    tree = doctree(source)
+    (ex, jin, jout) = tree.traverse(JupyterCellNode)
+    (ex_in, ex_out) = ex.children
+    (jin_in, _) = jin.children
+    (jout_out,) = jout.children
+    assert ex_in.children[0].rawsource.strip() == "2 + 2"
+    assert ex_out.children[0].rawsource.strip() == "4"
+    assert jin_in.children[0].rawsource.strip() == "3 + 3"
+    assert jout_out.children[0].rawsource.strip() == "5"

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -663,9 +663,11 @@ def test_input_cell(doctree):
     """
     tree = doctree(source)
     (cell,) = tree.traverse(JupyterCellNode)
-    (cellinput, _) = cell.children
+    (cellinput, empty) = cell.children
+    assert cell.attributes["hide_output"] is True
     assert cellinput.children[0].attributes["linenos"] is False
     assert cellinput.children[0].rawsource.strip() == "2 + 2"
+    assert len(empty.children) == 0
 
 def test_input_cell_linenos(doctree):
     source = """
@@ -676,9 +678,11 @@ def test_input_cell_linenos(doctree):
     """
     tree = doctree(source)
     (cell,) = tree.traverse(JupyterCellNode)
-    (cellinput, _) = cell.children
+    (cellinput, empty) = cell.children
+    assert cell.attributes["hide_output"] is True
     assert cellinput.children[0].attributes["linenos"] is True
     assert cellinput.children[0].rawsource.strip() == "2 + 2"
+    assert len(empty.children) == 0
 
 def test_output_cell(doctree):
     source = """


### PR DESCRIPTION
Proposed solution for issue #140 

~~Adds an extra option `dont-run` to cells which means they are not submitted for execution, just simply rendered as a cell.~~
~~Current drawback of this solution is that the cell is not included in the .ipynb or .py output files.~~
Adds two new directives, `jupyter-input` and `jupyter-output` which build a `CellInputNode` or `CellOutputNode` directly. These are added to the .ipynb and .py output files when built.
Comments and suggestions welcome.