### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest]
         include:
           - os: windows-latest

--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -8,6 +8,7 @@ import os
 from sphinx.util.fileutil import copy_asset
 from sphinx.errors import ExtensionError
 from IPython.lib.lexers import IPythonTracebackLexer, IPython3Lexer
+from pathlib import Path
 
 from .ast import (
     JupyterCell,
@@ -121,9 +122,12 @@ def build_finished(app, env):
     if app.builder.format != "html":
         return
 
+    module_path = Path(__file__)
+    outdir_path = Path(app.outdir)
+
     # Copy stylesheet
-    src = os.path.join(os.path.dirname(__file__), "css")
-    dst = os.path.join(app.outdir, "_static")
+    src = module_path / "css"
+    dst = outdir_path / "_static"
     copy_asset(src, dst)
 
     thebe_config = app.config.jupyter_sphinx_thebelab_config
@@ -131,8 +135,7 @@ def build_finished(app, env):
         return
 
     # Copy all thebelab related assets
-    src = os.path.join(os.path.dirname(__file__), "thebelab")
-    dst = os.path.join(app.outdir, "_static")
+    src = module_path / "thebelab"
     copy_asset(src, dst)
 
 

--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -122,12 +122,12 @@ def build_finished(app, env):
     if app.builder.format != "html":
         return
 
-    module_path = Path(__file__)
-    outdir_path = Path(app.outdir)
+    module_dir = Path(__file__).parent
+    outdir = Path(app.outdir)
 
     # Copy stylesheet
-    src = module_path / "css"
-    dst = outdir_path / "_static"
+    src = module_dir / "css"
+    dst = outdir / "_static"
     copy_asset(src, dst)
 
     thebe_config = app.config.jupyter_sphinx_thebelab_config
@@ -135,7 +135,7 @@ def build_finished(app, env):
         return
 
     # Copy all thebelab related assets
-    src = module_path / "thebelab"
+    src = module_dir / "thebelab"
     copy_asset(src, dst)
 
 

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -229,7 +229,7 @@ class JupyterWidgetStateNode(docutils.nodes.Element):
         )
 
 
-def cell_output_to_nodes(outputs, data_priority, write_stderr, dir, thebe_config):
+def cell_output_to_nodes(outputs, data_priority, write_stderr, out_dir, thebe_config):
     """Convert a jupyter cell with outputs and filenames to doctree nodes.
 
     Parameters
@@ -239,7 +239,7 @@ def cell_output_to_nodes(outputs, data_priority, write_stderr, dir, thebe_config
         Which media types to prioritize.
     write_stderr : bool
         If True include stderr in cell output
-    dir : string
+    out_dir : string
         Sphinx "absolute path" to the output folder, so it is a relative path
         to the source folder prefixed with ``/``.
     thebe_config: dict
@@ -305,19 +305,17 @@ def cell_output_to_nodes(outputs, data_priority, write_stderr, dir, thebe_config
                 continue
             data = output["data"][mime_type]
             if mime_type.startswith("image"):
+                file_path = Path(output.metadata["filenames"][mime_type])
+                out_dir = Path(out_dir)
                 # Sphinx treats absolute paths as being rooted at the source
                 # directory, so make a relative path, which Sphinx treats
                 # as being relative to the current working directory.
-                filename = os.path.basename(output.metadata["filenames"][mime_type])
+                filename = file_path.name
 
-                # checks if file dir path is inside a subdir of dir
-                filedir = os.path.dirname(output.metadata["filenames"][mime_type])
-                subpaths = filedir.split(dir)
-                if subpaths and len(subpaths) > 1:
-                    subpath = subpaths[1]
-                    dir += subpath
+                if out_dir in file_path.parents:
+                    out_dir = file_path.parent
 
-                uri = Path(os.path.join(dir, filename)).as_posix()
+                uri = (out_dir / filename).as_posix()
                 to_add.append(docutils.nodes.image(uri=uri))
             elif mime_type == "text/html":
                 to_add.append(

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -102,8 +102,7 @@ class JupyterCell(Directive):
                     location=location,
                 )
             try:
-                with open(filename) as f:
-                    content = [line.rstrip() for line in f.readlines()]
+                content = [line.rstrip() for line in Path(filename).read_text()]
             except (IOError, OSError):
                 raise IOError("File {} not found or reading it failed".format(filename))
         else:

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -102,7 +102,8 @@ class JupyterCell(Directive):
                     location=location,
                 )
             try:
-                content = [line.rstrip() for line in Path(filename).read_text()]
+                with Path(filename).open() as f:
+                    content = [line.rstrip() for line in f.readlines()]
             except (IOError, OSError):
                 raise IOError("File {} not found or reading it failed".format(filename))
         else:

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -2,6 +2,7 @@
 
 import os
 import json
+from pathlib import Path
 
 import docutils
 from docutils.parsers.rst import Directive, directives
@@ -316,7 +317,7 @@ def cell_output_to_nodes(outputs, data_priority, write_stderr, dir, thebe_config
                     subpath = subpaths[1]
                     dir += subpath
 
-                uri = os.path.join(dir, filename)
+                uri = Path(os.path.join(dir, filename)).as_posix()
                 to_add.append(docutils.nodes.image(uri=uri))
             elif mime_type == "text/html":
                 to_add.append(

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -270,8 +270,7 @@ def write_notebook_output(notebook, output_dir, notebook_name, location=None):
 
     notebook_file = notebook_name + ext
     output_dir = Path(output_dir)
-    with (output_dir / notebook_file).open("w", encoding = "utf8") as f:
-        f.write(contents)
+    (output_dir / notebook_file).write_text(contents, encoding = "utf8")
 
 
 def contains_widgets(notebook):

--- a/jupyter_sphinx/thebelab.py
+++ b/jupyter_sphinx/thebelab.py
@@ -3,6 +3,7 @@ import os
 import json
 import docutils
 from docutils.parsers.rst import Directive
+from pathlib import Path
 
 import jupyter_sphinx as js
 
@@ -86,16 +87,17 @@ def add_thebelab_library(doctree, env):
     if isinstance(thebe_config, dict):
         pass
     elif isinstance(thebe_config, str):
-        if os.path.isabs(thebe_config):
+        thebe_config = Path(thebe_config)
+        if thebe_config.is_absolute():
             filename = thebe_config
         else:
-            filename = os.path.join(os.path.abspath(env.app.srcdir), thebe_config)
+            filename = Path(env.app.srcdir).resolve() / thebe_config
 
-        if not os.path.exists(filename):
+        if not filename.exists():
             js.logger.warning("The supplied thebelab configuration file does not exist")
             return
 
-        with open(filename, "r") as config_file:
+        with filename.open("r") as config_file:
             try:
                 thebe_config = json.load(config_file)
             except ValueError:

--- a/jupyter_sphinx/thebelab.py
+++ b/jupyter_sphinx/thebelab.py
@@ -98,7 +98,7 @@ def add_thebelab_library(doctree, env):
             return
 
         try:
-            thebe_config = json.load(filename.read_bytes())
+            thebe_config = json.loads(filename.read_text())
         except ValueError:
             js.logger.warning(
                 "The supplied thebelab configuration file is not in JSON format."

--- a/jupyter_sphinx/thebelab.py
+++ b/jupyter_sphinx/thebelab.py
@@ -97,14 +97,13 @@ def add_thebelab_library(doctree, env):
             js.logger.warning("The supplied thebelab configuration file does not exist")
             return
 
-        with filename.open("r") as config_file:
-            try:
-                thebe_config = json.load(config_file)
-            except ValueError:
-                js.logger.warning(
-                    "The supplied thebelab configuration file is not in JSON format."
-                )
-                return
+        try:
+            thebe_config = json.load(filename.read_bytes())
+        except ValueError:
+            js.logger.warning(
+                "The supplied thebelab configuration file is not in JSON format."
+            )
+            return
     else:
         js.logger.warning(
             "The supplied thebelab configuration should be either a filename or a dictionary."

--- a/jupyter_sphinx/utils.py
+++ b/jupyter_sphinx/utils.py
@@ -75,20 +75,13 @@ def sphinx_abs_dir(env, *paths):
     # output_directory / jupyter_execute / path relative to source directory
     # Sphinx expects download links relative to source file or relative to
     # source dir and prepended with '/'. We use the latter option.
-    out_path = Path(
-        os.path.abspath(
-            os.path.join(output_directory(env), os.path.dirname(env.docname), *paths)
-        )
-    ).as_posix()
-    
+    out_path = (output_directory(env) /  Path(env.docname).parent / Path(*paths)).resolve()
+      
     if os.name == "nt":
         # Can't get relative path between drives on Windows
-        return out_path
+        return out_path.as_posix()
 
-    return "/" + os.path.relpath(
-            out_path,
-            os.path.abspath(env.app.srcdir),
-        )
+    return "/" + out_path.relative_to(env.app.srcdir).as_posix()
 
 
 def output_directory(env):
@@ -99,6 +92,4 @@ def output_directory(env):
 
     # Note: we are using an implicit fact that sphinx output directories are
     # direct subfolders of the build directory.
-    return os.path.abspath(
-        os.path.join(env.app.outdir, os.path.pardir, "jupyter_execute")
-    )
+    return (Path(env.app.outdir) / os.path.pardir / "jupyter_execute").resolve()

--- a/jupyter_sphinx/utils.py
+++ b/jupyter_sphinx/utils.py
@@ -81,7 +81,8 @@ def sphinx_abs_dir(env, *paths):
         # Can't get relative path between drives on Windows
         return out_path.as_posix()
 
-    return "/" + out_path.relative_to(env.app.srcdir).as_posix()
+    # Path().relative_to() doesn't work when not a direct subpath
+    return "/" + os.path.relpath(out_path, env.app.srcdir)
 
 
 def output_directory(env):

--- a/jupyter_sphinx/utils.py
+++ b/jupyter_sphinx/utils.py
@@ -4,6 +4,7 @@ from itertools import groupby, count
 from sphinx.errors import ExtensionError
 import nbformat
 from jupyter_client.kernelspec import get_kernel_spec, NoSuchKernel
+from pathlib import Path
 
 
 def blank_nb(kernel_name):
@@ -74,12 +75,20 @@ def sphinx_abs_dir(env, *paths):
     # output_directory / jupyter_execute / path relative to source directory
     # Sphinx expects download links relative to source file or relative to
     # source dir and prepended with '/'. We use the latter option.
-    return "/" + os.path.relpath(
+    out_path = Path(
         os.path.abspath(
             os.path.join(output_directory(env), os.path.dirname(env.docname), *paths)
-        ),
-        os.path.abspath(env.app.srcdir),
-    )
+        )
+    ).as_posix()
+    
+    if os.name == "nt":
+        # Can't get relative path between drives on Windows
+        return out_path
+
+    return "/" + os.path.relpath(
+            out_path,
+            os.path.abspath(env.app.srcdir),
+        )
 
 
 def output_directory(env):

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
         "nbconvert>=5.5",
         "nbformat",
     ],
-    python_requires=">= 3.5",
+    python_requires=">= 3.6",
     package_data={"jupyter_sphinx": ["thebelab/*", "css/*"]},
 )

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -4,6 +4,7 @@ import os
 import sys
 from io import StringIO
 from unittest.mock import Mock
+from pathlib import Path
 
 from sphinx.addnodes import download_reference
 from sphinx.testing.util import assert_node, SphinxTestApp, path
@@ -586,6 +587,11 @@ def test_download_role(text, reftarget, caption, tmp_path):
     }
     mock_inliner.configure_mock(**config)
     ret, msg = role('jupyter-download:notebook', text, text, 0, mock_inliner)
+
+    if os.name == "nt":
+        # Get equivalent abs path for Windows
+        reftarget = Path(os.path.join(tmp_path, reftarget[1:])).resolve().as_posix()
+
     assert_node(ret[0], [download_reference], reftarget=reftarget)
     assert_node(ret[0][0], [literal, caption])
     assert msg == []

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -37,10 +37,13 @@ def doctree():
     ):
         src_dir = Path(tempfile.mkdtemp())
         source_trees.append(src_dir.as_posix())
-        (src_dir / "conf.py").write_text("extensions = ['%s']" % entrypoint, encoding = "utf8")
+
+        conf_contents = "extensions = ['%s']" % entrypoint
         if config is not None:
-            f.write("\n" + config)
+            conf_contents += "\n" + config
+        (src_dir / "conf.py").write_text(conf_contents, encoding = "utf8")
         (src_dir / "contents.rst").write_text(source, encoding = "utf8")
+        
         warnings = StringIO()
         app = SphinxTestApp(srcdir=path(src_dir.as_posix()), status=StringIO(), warning=warnings)
         apps.append(app)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -36,7 +36,7 @@ def doctree():
         source, config=None, return_warnings=False, entrypoint="jupyter_sphinx"
     ):
         src_dir = Path(tempfile.mkdtemp())
-        source_trees.append(src_dir.as_posix())
+        source_trees.append(src_dir)
 
         conf_contents = "extensions = ['%s']" % entrypoint
         if config is not None:

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -35,13 +35,13 @@ def doctree():
     def doctree(
         source, config=None, return_warnings=False, entrypoint="jupyter_sphinx"
     ):
-        src_dir = tempfile.mkdtemp()
+        src_dir = Path(tempfile.mkdtemp())
         source_trees.append(src_dir)
-        with open(os.path.join(src_dir, "conf.py"), "w", encoding = "utf8") as f:
+        with (src_dir / "conf.py").open("w", encoding = "utf8") as f:
             f.write("extensions = ['%s']" % entrypoint)
             if config is not None:
                 f.write("\n" + config)
-        with open(os.path.join(src_dir, "contents.rst"), "w", encoding = "utf8") as f:
+        with (src_dir / "contents.rst").open("w", encoding = "utf8") as f:
             f.write(source)
         warnings = StringIO()
         app = SphinxTestApp(srcdir=path(src_dir), status=StringIO(), warning=warnings)
@@ -590,7 +590,7 @@ def test_download_role(text, reftarget, caption, tmp_path):
 
     if os.name == "nt":
         # Get equivalent abs path for Windows
-        reftarget = Path(os.path.join(tmp_path, reftarget[1:])).resolve().as_posix()
+        reftarget = (Path(tmp_path) / reftarget[1:]).resolve().as_posix()
 
     assert_node(ret[0], [download_reference], reftarget=reftarget)
     assert_node(ret[0][0], [literal, caption])

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -44,7 +44,7 @@ def doctree():
         with (src_dir / "contents.rst").open("w", encoding = "utf8") as f:
             f.write(source)
         warnings = StringIO()
-        app = SphinxTestApp(srcdir=path(src_dir), status=StringIO(), warning=warnings)
+        app = SphinxTestApp(srcdir=path(src_dir.as_posix()), status=StringIO(), warning=warnings)
         apps.append(app)
         app.build()
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -36,13 +36,11 @@ def doctree():
         source, config=None, return_warnings=False, entrypoint="jupyter_sphinx"
     ):
         src_dir = Path(tempfile.mkdtemp())
-        source_trees.append(src_dir)
-        with (src_dir / "conf.py").open("w", encoding = "utf8") as f:
-            f.write("extensions = ['%s']" % entrypoint)
-            if config is not None:
-                f.write("\n" + config)
-        with (src_dir / "contents.rst").open("w", encoding = "utf8") as f:
-            f.write(source)
+        source_trees.append(src_dir.as_posix())
+        (src_dir / "conf.py").write_text("extensions = ['%s']" % entrypoint, encoding = "utf8")
+        if config is not None:
+            f.write("\n" + config)
+        (src_dir / "contents.rst").write_text(source, encoding = "utf8")
         warnings = StringIO()
         app = SphinxTestApp(srcdir=path(src_dir.as_posix()), status=StringIO(), warning=warnings)
         apps.append(app)


### PR DESCRIPTION
- [x] Non-posix paths are causing CI to fail on Windows. Converted to posix

- [x] `sphinx_abs_dir` tries to get the relative path between two Windows drives when testing. Changed to use absolute path on Windows

- [x] tests check that  `sphinx_abs_dir` output is relative path using `assert_node`. Updated `test_download_role` to check if Windows absolute path is equivalent to the relative reftarget.

Fixes #143, fixes #54
Should fix some issues in Windows tests at executablebooks/jupyter-book#723