### PR TITLE
properly store cm_language in node attributes

### DIFF
--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -370,7 +370,7 @@ def cell_output_to_nodes(outputs, data_priority, write_stderr, out_dir,
     return to_add
 
 
-def attach_outputs(output_nodes, node, thebe_config, cm_language):
+def attach_outputs(output_nodes, node, thebe_config):
     if not node.attributes["hide_code"]:  # only add css if code is displayed
         classes = node.attributes.get("classes", [])
         classes += ["jupyter_container"]
@@ -384,7 +384,7 @@ def attach_outputs(output_nodes, node, thebe_config, cm_language):
         thebe_source = ThebeSourceNode(
             hide_code=node.attributes["hide_code"],
             code_below=node.attributes["code_below"],
-            language=cm_language,
+            language=node.attributes["cm_language"],
         )
         thebe_source.children = [source]
         input_node.children = [thebe_source]
@@ -451,7 +451,7 @@ class CellOutputsToNodes(SphinxTransform):
                 thebe_config,
             )
             # Remove the outputbundlenode and we'll attach the outputs next
-            attach_outputs(output_nodes, cell_node, thebe_config, cell_node.cm_language)
+            attach_outputs(output_nodes, cell_node, thebe_config)
 
         # Image collect extra nodes from cell outputs that we need to process
         for node in self.document.traverse(image):

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -214,7 +214,7 @@ class ExecuteJupyterCells(SphinxTransform):
             except AttributeError:
                 cm_language = notebook.metadata.kernelspec.language
             for node in nodes:
-                node.cm_language = cm_language
+                node.attributes["cm_language"] = cm_language
 
             # Add doctree nodes for cell outputs.
             for node, cell in zip(nodes, notebook.cells):

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -33,7 +33,11 @@ def doctree():
     syspath = sys.path[:]
 
     def doctree(
-        source, config=None, return_warnings=False, entrypoint="jupyter_sphinx"
+        source,
+        config=None,
+        return_warnings=False,
+        entrypoint="jupyter_sphinx",
+        buildername='html'
     ):
         src_dir = Path(tempfile.mkdtemp())
         source_trees.append(src_dir)
@@ -45,7 +49,12 @@ def doctree():
         (src_dir / "contents.rst").write_text(source, encoding = "utf8")
         
         warnings = StringIO()
-        app = SphinxTestApp(srcdir=path(src_dir.as_posix()), status=StringIO(), warning=warnings)
+        app = SphinxTestApp(
+            srcdir=path(src_dir.as_posix()),
+            status=StringIO(),
+            warning=warnings,
+            buildername=buildername
+        )
         apps.append(app)
         app.build()
 
@@ -65,13 +74,14 @@ def doctree():
         shutil.rmtree(tree)
 
 
-def test_basic(doctree):
+@pytest.mark.parametrize('buildername', ['html', 'singlehtml'])
+def test_basic(doctree, buildername):
     source = """
     .. jupyter-execute::
 
         2 + 2
     """
-    tree = doctree(source)
+    tree = doctree(source, buildername=buildername)
     (cell,) = tree.traverse(JupyterCellNode)
     (cellinput, celloutput) = cell.children
     assert cell.attributes["code_below"] is False


### PR DESCRIPTION
That was easier than expected :facepalm: 

Closes #126, and also adds a test with singlehtml builder.

Pinging @chrisjsewell because of a minor API change. I'd like to confirm that I don't break anything on your side.