### PR TITLE
Fix handling of math in outputs

### DIFF
--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -272,7 +272,7 @@ def setup(app):
     app.add_role("jupyter-download:nb", JupyterDownloadRole())
     app.add_role("jupyter-download:script", JupyterDownloadRole())
     app.add_transform(ExecuteJupyterCells)
-    app.add_post_transform(CellOutputsToNodes)
+    app.add_transform(CellOutputsToNodes)
 
     # For syntax highlighting
     app.add_lexer("ipythontb", IPythonTracebackLexer)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -46,7 +46,7 @@ def doctree():
         if config is not None:
             conf_contents += "\n" + config
         (src_dir / "conf.py").write_text(conf_contents, encoding = "utf8")
-        (src_dir / "contents.rst").write_text(source, encoding = "utf8")
+        (src_dir / "index.rst").write_text(source, encoding = "utf8")
         
         warnings = StringIO()
         app = SphinxTestApp(
@@ -58,7 +58,7 @@ def doctree():
         apps.append(app)
         app.build()
 
-        doctree = app.env.get_and_resolve_doctree("contents", app.builder)
+        doctree = app.env.get_and_resolve_doctree("index", app.builder)
 
         if return_warnings:
             return doctree, warnings.getvalue()


### PR DESCRIPTION
Domain resolution (and in particular math domain resolution) happens before post_transforms. Therefore it seems like the only option to correctly include mathjax math is to move including outputs from a post transform to a transform, like I do in this PR.

Closes #134

I'm unsure about the implications and appropriateness of this though. The tests still pass and the docs look good.

@chrisjsewell can you please give some advice/explanation here? Is there a downside I'm overlooking?

PS this is the last PR in 0.3 milestone aside of cleanup ;)