### PR TITLE
use nbconvert to write scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        python -m bash_kernel.install  # For testing a non-standard kernel
         pip install .
 
     - name: Run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ nbformat
 # For documentation building and testing
 matplotlib
 pytest
+
+# A non-standard kernel
+bash_kernel

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -635,6 +635,9 @@ def test_save_script(doctree):
 
 def test_bash_kernel(doctree):
     pytest.importorskip('bash_kernel')
+    if sys.platform == 'win32':
+        pytest.skip("Not trying bash on windows.")
+
     source = """
     .. jupyter-kernel:: bash
       :id: test

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -59,7 +59,6 @@ def doctree():
         app.build()
 
         doctree = app.env.get_and_resolve_doctree("index", app.builder)
-
         if return_warnings:
             return doctree, warnings.getvalue()
         else:


### PR DESCRIPTION
Compared to the current implementation

- Adds a correct shebang for known langauges
- If a comment format is known, converts markdown to comments
- Falls back gracefully to only include code cells if it doesn't know what to do

@chrisjsewell :point_up: I think this supersedes #159 

I think we could lean more on the nbconvert API, but this seems like a direct incremental improvement over what we have now.