### PR TITLE
Fix syntax highlighting logic.

### DIFF
--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -282,7 +282,7 @@ def setup(app):
 
     # For syntax highlighting
     app.add_lexer("ipythontb", IPythonTracebackLexer)
-    app.add_lexer("ipython", IPython3Lexer)
+    app.add_lexer("ipython3", IPython3Lexer)
 
     app.connect("builder-inited", builder_inited)
     app.connect("build-finished", build_finished)

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -204,7 +204,7 @@ class ExecuteJupyterCells(SphinxTransform):
 
             # Highlight the code cells now that we know what language they are
             for node in nodes:
-                source = node.children[0]
+                source = node.children[0].children[0]
                 source.attributes["language"] = lexer
 
             # Add line numbering


### PR DESCRIPTION
Previously, the language attribute was being set on the wrong node,
causing sphinx to use the default Python 3 highlighting for all
jupyter-execute blocks. In addition, the IPython3 lexer was being given
the wrong name. This commit fixes those issues, causing ipython %magic
commands to be highlighted correctly, and allowing non-Python-3 kernels
to use their own highlighting.