### PR TITLE
fix: escape the closing script when dumping the outcell

### DIFF
--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -388,13 +388,15 @@ class JupyterWidgetStateNode(docutils.nodes.Element):
         super().__init__("", state=attributes["state"])
 
     def html(self):
+        
+        # escape </script> to avoid early closing of the tag in the html page 
+        json_data = json.dumps(self["state"]).replace("</script>", r"<\/script>")
+        
         # TODO: render into a separate file if 'html-manager' starts fully
         #       parsing script tags, and not just grabbing their innerHTML
         # https://github.com/jupyter-widgets/ipywidgets/blob/master/packages/html-manager/src/libembed.ts#L36
         return ipywidgets.embed.snippet_template.format(
-            load="", 
-            widget_views="", 
-            json_data=json.dumps(self["state"]).replace("</script>", r"<\/script>")
+            load="", widget_views="", json_data=json_data
         )
 
 def cell_output_to_nodes(outputs, write_stderr, out_dir,

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -394,7 +394,7 @@ class JupyterWidgetStateNode(docutils.nodes.Element):
         return ipywidgets.embed.snippet_template.format(
             load="", 
             widget_views="", 
-            json_data=json.dumps(self["state"]).replace("</script>", "&lt/script>")
+            json_data=json.dumps(self["state"]).replace("</script>", r"<\/script>")
         )
 
 def cell_output_to_nodes(outputs, write_stderr, out_dir,

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -392,9 +392,11 @@ class JupyterWidgetStateNode(docutils.nodes.Element):
         #       parsing script tags, and not just grabbing their innerHTML
         # https://github.com/jupyter-widgets/ipywidgets/blob/master/packages/html-manager/src/libembed.ts#L36
         return ipywidgets.embed.snippet_template.format(
-            load="", widget_views="", json_data=json.dumps(self["state"])
+            load="", 
+            widget_views="", 
+            json_data=json.dumps(self["state"]).replace("</script>", "&lt/script>")
         )
-
+    
 
 def cell_output_to_nodes(outputs, write_stderr, out_dir,
                          thebe_config, inline=False):

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -396,7 +396,6 @@ class JupyterWidgetStateNode(docutils.nodes.Element):
             widget_views="", 
             json_data=json.dumps(self["state"]).replace("</script>", "&lt/script>")
         )
-    
 
 def cell_output_to_nodes(outputs, write_stderr, out_dir,
                          thebe_config, inline=False):


### PR DESCRIPTION
Fix #184