### PR TITLE
Fix for compat for ipywidgets and ipynb

### DIFF
--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -606,7 +606,13 @@ class JupyterDownloadRole(ReferenceRole):
 def get_widgets(notebook):
     try:
         return notebook.metadata.widgets[WIDGET_STATE_MIMETYPE]
-    except (AttributeError, KeyError):
+    except KeyError:
+        from . import logger
+        logger.warning(
+                'Unable to get widget state in current notebook - are you sure that pywidgets rendered correctly in all your notebooks ?'
+        )
+        return None
+    except AttributeError:
         return None
 
 


### PR DESCRIPTION
We had issues with some serialised state from ipywidgets in notebook. 

It was working fine when we using `nbsphinx` and old pinned dependencies - however when updating to latest sphinx and packages an exception was raised here. It seems it was excepted but that the wrong exception was caught - and that the exact type of exception to capture depends on other dependencies. I believe this change should be reasonable.