### PR TITLE
Do not overwrite files in _static if user already has custom versions of those files

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -413,6 +413,10 @@ Here is a sample ``custom.css`` file overriding the ``stderr`` background color:
   }
 
 
+Alternatively, you can also completely overwrite the CSS and JS files that are added by Jupyter Sphinx by providing a full copy of a ``jupyter-sphinx.css`` (which can be empty) file in your ``_static`` folder.
+This is also possible with the thebelab CSS and JS that is added.
+
+
 Configuration options
 ---------------------
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -478,6 +478,7 @@ Release 0.4.0
 - Remove deprecated enabling of the extension as ``jupyter_sphinx.execute``.
 - Implement different output priorities in HTML and LaTeX builders. In practice this allows to provide a better fallback in PDF output.
 - Introduce new ``jupyter-download`` syntax compatible with Sphinx≥4, ``jupyter-download-nb``, ``jupyter-download-notebook``, and ``jupyter-download-script``
+- Do not overwrite CSS and JS if files already exist in _static/, this allows to customize the CSS and JS file.
 
 Release 0.3.0
 ~~~~~~~~~~~~~

--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -113,25 +113,30 @@ def builder_inited(app):
         app.add_js_file(embed_url)
 
 
+def copy_file(src, dst):
+    if not (dst / src.name).exists():
+        copy_asset(str(src), str(dst))
+
+
 def build_finished(app, env):
     if app.builder.format != "html":
         return
 
     module_dir = Path(__file__).parent
-    outdir = Path(app.outdir)
+    static = Path(app.outdir) / "_static"
 
     # Copy stylesheet
-    src = module_dir / "css"
-    dst = outdir / "_static"
-    copy_asset(src, dst)
+    src = module_dir / "css" / "jupyter-sphinx.css"
+    copy_file(src, static)
 
     thebe_config = app.config.jupyter_sphinx_thebelab_config
     if not thebe_config:
         return
 
     # Copy all thebelab related assets
-    src = module_dir / "thebelab"
-    copy_asset(src, dst)
+    src_dir = module_dir / "thebelab"
+    for fname in ["thebelab-helper.js", "thebelab.css"]:
+        copy_file(src_dir / fname, static)
 
 
 ##############################################################################


### PR DESCRIPTION
The CSS files are always copied in `build_finished`, this prevents one from overwriting any of the CSS files.