### PR TITLE
Configurable pre-notebook cell

### DIFF
--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -193,6 +193,13 @@ def setup(app):
     app.add_config_value("jupyter_sphinx_linenos", False, "env")
     app.add_config_value("jupyter_sphinx_continue_linenos", False, "env")
 
+    # pre-notebook setup cell
+    app.add_config_value(
+        "jupyter_execute_pre_notebook",
+        None,
+        "env",
+    )
+
     # JupyterKernelNode is just a doctree marker for the
     # ExecuteJupyterCells transform, so we don't actually render it.
     app.add_node(

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -155,12 +155,17 @@ class ExecuteJupyterCells(SphinxTransform):
             # Add empty placeholder cells for non-executed nodes so nodes
             # and cells can be zipped and the provided input/output
             # can be inserted later
+            code_cells = [
+                nbformat.v4.new_code_cell(node.astext() if node["execute"] else "")
+                for node in nodes
+            ]
+            if self.config.jupyter_execute_pre_notebook:
+                code_cells = [
+                    nbformat.v4.new_code_cell(self.config.jupyter_execute_pre_notebook)
+                ] + code_cells
             notebook = execute_cells(
                 kernel_name,
-                [
-                    nbformat.v4.new_code_cell(node.astext() if node["execute"] else "")
-                    for node in nodes
-                ],
+                code_cells,
                 self.config.jupyter_execute_kwargs,
             )
 

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -766,3 +766,12 @@ def test_builder_priority(doctree):
     _, app, _ = doctree(source, config=config, return_all=True, buildername="latex")
     latex = (Path(app.outdir) / "python.tex").read_text()
     assert "I am latex" in latex
+
+
+def test_pre_notebook_cell(doctree):
+    source = """
+    .. jupyter-execute::
+
+        sys.executable
+    """
+    doctree(source, config="jupyter_execute_pre_notebook = 'import sys'")


### PR DESCRIPTION
This is an excellent project and has proven very useful, but in some environments we end up having a lot of boilerplate required to setup the notebook before things are run, which gets repeated throughout the codebase when kernels are reset. 

To avoid having the hidden block in multiple places:

```
.. jupyter-kernel:: python3

.. jupyter-execute::
    :hide-code:
    
    import setup
    setup()

.. jupyter-execute::

    # example code goes here

```

Instead it would be nice to configure some constant setup cell that is inserted at the top of the notebook

conf.py:
```
jupyter_execute_pre_notebook = "import setup\nsetup()"
```

Then all execute blocks are already setup without the extra boilerplate:

```
.. jupyter-kernel:: python3

.. jupyter-execute::

    # example code goes here
```