### PR TITLE
Add direct dependency on ipykernel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sphinx>=2.4.4
+ipykernel>=4.5.1
 ipywidgets>=7.0.0
 IPython
 nbconvert>=5.4

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     packages=["jupyter_sphinx"],
     install_requires=[
         "Sphinx>=2",
+        "ipykernel>=4.5.1",
         "ipywidgets>=7.0.0",
         "IPython",
         "nbconvert>=5.5",


### PR DESCRIPTION
ipywidgets 8.1.0 has been released, which includes the change at https://github.com/jupyter-widgets/ipywidgets/pull/3811. With this change, ipykernel is no longer a dependency of ipywidgets, so jupyer-sphinx must now depend on ipykernel directly rather than assume it will be installed as a transitive dependency of ipywidgets.  Without this change, jupyter-sphinx tests will fail CI. This has additionally led to CI failures in some packages that depend on jupyter-sphinx but not ipykernel.

The minimum version chosen here is the same minimum version that was formerly specified by ipywidgets until https://github.com/jupyter-widgets/ipywidgets/pull/3811.