### PR TITLE
drop support for Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         os: [ubuntu-latest]
         include:
           - os: windows-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-  - repo: "https://gitlab.com/pycqa/flake8/"
+  - repo: "https://github.com/pycqa/flake8/"
     rev: 3.9.2
     hooks:
       - id: flake8
@@ -14,7 +14,7 @@ repos:
       - id: black
         language_version: python3
   - repo: "https://github.com/PyCQA/isort"
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
         "nbconvert>=5.5",
         "nbformat",
     ],
-    python_requires=">= 3.6",
+    python_requires=">= 3.7",
     package_data={"jupyter_sphinx": ["thebelab/*", "css/*"]},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37
+envlist = py37
 
 [testenv]
 deps =


### PR DESCRIPTION
Fix #228 

As mentioned in the issue, 3.6 is not supported by ubuntu-latest runners in github actions. 
I simply dropped it from the test and the actions. 

I also identified issues in the pycqa url in the pre-commit (flake8 came back to github) and isort version had a deprecated poetry config so I moved it to the latest one. 