### PR TITLE
Remove sphinx.testing.util.path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=2.4.4
+sphinx>=7.2
 ipywidgets>=7.0.0
 IPython
 nbconvert>=5.4

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,12 @@ setup(
     license="BSD",
     packages=["jupyter_sphinx"],
     install_requires=[
-        "Sphinx>=2",
+        "Sphinx>=7.2",
         "ipywidgets>=7.0.0",
         "IPython",
         "nbconvert>=5.5",
         "nbformat",
     ],
-    python_requires=">= 3.6",
+    python_requires=">= 3.8",
     package_data={"jupyter_sphinx": ["thebelab/*", "css/*"]},
 )

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -12,7 +12,7 @@ from docutils.nodes import container, image, literal, literal_block, math_block,
 from nbformat import from_dict
 from sphinx.addnodes import download_reference
 from sphinx.errors import ExtensionError
-from sphinx.testing.util import SphinxTestApp, assert_node, path
+from sphinx.testing.util import SphinxTestApp, assert_node
 
 from jupyter_sphinx.ast import (
     JupyterCellNode,
@@ -48,7 +48,7 @@ def doctree():
 
         warnings = StringIO()
         app = SphinxTestApp(
-            srcdir=path(src_dir.as_posix()),
+            srcdir=src_dir,
             status=StringIO(),
             warning=warnings,
             buildername=buildername,

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py36,py37
+envlist = py38,py311
 
 [testenv]
 deps =
-  sphinx
+  sphinx >= 7.2
   pytest
 commands =
   pytest


### PR DESCRIPTION
Fixes #232 

Sphinx went full `pathlib` in 7.2. So let's don't bother with compatibility checks and just bump the minversion.
Also alinged the minversion of Python with what is currently maintained.