### PR TITLE
docs: change default branch name to main

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,31 +7,31 @@ To cut a new Jupyter Sphinx release, follow these steps:
 
 - Ensure that all tests are passing on master.
 
-- In [`_version.py`](https://github.com/jupyter/jupyter-sphinx/blob/master/jupyter_sphinx/_version.py),
+- In [`_version.py`](https://github.com/jupyter/jupyter-sphinx/blob/main/jupyter_sphinx/_version.py),
   change the "release type" section to "final" e.g.:
 
   ```python
   version_info = (0, 2, 3, "final")
   ```
 
-- Make a release commit and push to master
+- Make a release commit and push to main
 
   ```
   git add jupyter_sphinx/_version.py
   git commit -m "RLS: 0.2.3"
-  git push upstream master
+  git push upstream main
   ```
 
 - [Create a new github release](https://github.com/jupyter/jupyter-sphinx/releases/new).
-  The target should be **master**, the tag and the title should be the version number,
+  The target should be **main**, the tag and the title should be the version number,
   e.g. `0.2.3`.
 
 - Creating the release in GitHub will push a tag commit to the repository, which will
-  trigger [a GitHub action](https://github.com/jupyter/jupyter-sphinx/blob/master/.github/workflows/artifacts.yml)
+  trigger [a GitHub action](https://github.com/jupyter/jupyter-sphinx/blob/main/.github/workflows/artifacts.yml)
   to build `jupyter-sphinx` and push the new version to PyPI.
   [Confirm that the version has been bumped](https://pypi.org/project/jupyter-sphinx/).
 
-- In [`_version.py`](https://github.com/jupyter/jupyter-sphinx/blob/master/jupyter_sphinx/_version.py),
+- In [`_version.py`](https://github.com/jupyter/jupyter-sphinx/blob/main/jupyter_sphinx/_version.py),
   bump the minor version and change the "release type" section to "alpha". **make sure to
   include a number after the release type**, e.g.:
 


### PR DESCRIPTION
The RELEASE.md file is copy/pasted from anothe repository and is still using the old "master" convention for the default branch. 

I simply replaced occurences with "main".