### PR TITLE
test: create a prerelease job

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,7 +3,7 @@ name: Scheduled pre-release tests
 on:
   # Run this workflow once a week (https://crontab.guru/#0_5_*_*_1)
   schedule:
-    - cron: "0 5 * * 1,4"
+    - cron: "0 5 * * 1"
   workflow_dispatch:
 
 # env variable to force pip to install pre-released versions

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,46 @@
+name: Scheduled pre-release tests
+
+on:
+  # Run this workflow once a week (https://crontab.guru/#0_5_*_*_1)
+  schedule:
+    - cron: "0 5 * * 1,4"
+  workflow_dispatch:
+
+# env variable to force pip to install pre-released versions
+# in hatch envs
+env:
+  PIP_PRE: 1
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", " 3.12"]
+        os: [ubuntu-latest]
+        include:
+          - os: windows-latest
+            python-version: "3.12"
+          - os: macos-latest
+            python-version: "3.12"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: pip install hatch
+      - name: Run tests
+        run: hatch run test:test -x
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: pip install hatch
+
+      - name: Build docs
+        run: hatch run doc:build


### PR DESCRIPTION
Test the lib against the pre-released version of its dependencies. 
Very useful considering the release cycle of `Sphinx` which is regularly breaking things in its exposed API as they are cleaning it. 

This PR includes: 
- a new workflow file that can be dispatched and is run every week (Monday 5 GMT)
- a simplified version of the tests: `--upgrade` is not necessary on fresh envs as there is no cache and I removed line break for one-liners. 
- test is run using a env variable PIP_PRE that will force the installation of pre-released libs as discussed in https://github.com/pypa/hatch/issues/603