### PR TITLE
build: use double quote in yaml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python "3.10"
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Build package
         run: |
           pip install wheel


### PR DESCRIPTION
The latest released failed because as "3.10" was interpreted as "3.1"