### PR TITLE
refactor: update metadata content in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "jupyter-sphinx"
 dynamic = ["version"]
 description = "Jupyter Sphinx Extensions"
 requires-python = ">=3.8"
-]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ name = "Jupyter Development Team"
 email = "jupyter@googlegroups.com"
 
 [project.license]
-text = "BSD"
 file = "LICENSE"
 
 [project.readme]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,22 @@ build-backend = "hatchling.build"
 name = "jupyter-sphinx"
 dynamic = ["version"]
 description = "Jupyter Sphinx Extensions"
-readme = "README.md"
-license = {file="LICENSE"}
 requires-python = ">=3.8"
-authors = [
-    { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering"
 ]
 dependencies = [
     "ipykernel>=4.5.1",
@@ -20,6 +31,18 @@ dependencies = [
     "nbformat",
     "Sphinx>=7",
 ]
+
+[[project.authors]]
+name = "Jupyter Development Team"
+email = "jupyter@googlegroups.com"
+
+[project.license]
+text = "BSD"
+file = "LICENSE"
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/jupyter/jupyter-sphinx/issues/"


### PR DESCRIPTION
Fix #262 

I addded all the classifier for the pypi release, moved the redme, license and authors sections out of the project main description.