### PR TITLE
chore: update the commit hooks list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,59 +1,41 @@
-ci:
-  autoupdate_schedule: monthly
-  autoupdate_commit_msg: "chore: update pre-commit hooks"
-
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+  - repo: "https://github.com/psf/black"
+    rev: "22.3.0"
     hooks:
-      - id: check-case-conflict
-      - id: check-ast
-      - id: check-docstring-first
-      - id: check-executables-have-shebangs
-      - id: check-added-large-files
-      - id: check-case-conflict
-      - id: check-merge-conflict
-      - id: check-json
-      - id: check-toml
-      - id: check-yaml
-      - id: debug-statements
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
+      - id: black
 
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.1
+  - repo: "https://github.com/kynan/nbstripout"
+    rev: "0.5.0"
     hooks:
-      - id: check-github-workflows
+      - id: nbstripout
 
-  - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
-    hooks:
-      - id: mdformat
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.3"
+  - repo: "https://github.com/pre-commit/mirrors-prettier"
+    rev: "v2.7.1"
     hooks:
       - id: prettier
-        types_or: [yaml, html, json]
+        exclude: tests\/test_.+\.
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.6"
-    hooks:
-      - id: codespell
-        args: ["-L", "sur,nd"]
-
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: "v1.10.0"
-    hooks:
-      - id: rst-backticks
-      - id: rst-directive-colons
-      - id: rst-inline-touching-normal
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.5
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.215"
     hooks:
       - id: ruff
-        types_or: [python, jupyter]
-        args: ["--fix", "--show-fixes"]
-      - id: ruff-format
-        types_or: [python, jupyter]
+
+  - repo: https://github.com/PyCQA/doc8
+    rev: "v1.1.1"
+    hooks:
+      - id: doc8
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+      - id: codespell
+        stages: [commit]
+        additional_dependencies:
+          - tomli
+
+  # Prevent committing inline conflict markers
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-merge-conflict
+        args: [--assume-in-merge]

--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -110,7 +110,7 @@ def builder_inited(app: Sphinx):
 
 
 def copy_file(src: Path, dst: Path):
-    """wrapper of copy_asset_file to handle path"""
+    """Wrapper of copy_asset_file to handle path."""
     copy_asset_file(str(src.resolve()), str(dst.resolve()))
 
 

--- a/jupyter_sphinx/__init__.py
+++ b/jupyter_sphinx/__init__.py
@@ -28,9 +28,7 @@ from .ast import (
 from .execute import ExecuteJupyterCells, JupyterKernel
 from .thebelab import ThebeButton, ThebeButtonNode, ThebeOutputNode, ThebeSourceNode
 
-REQUIRE_URL_DEFAULT = (
-    "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"
-)
+REQUIRE_URL_DEFAULT = "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"
 THEBELAB_URL_DEFAULT = "https://unpkg.com/thebelab@^0.4.0"
 
 logger = logging.getLogger(__name__)
@@ -92,23 +90,20 @@ render_thebe_source = (
 
 # Sphinx callback functions
 def builder_inited(app):
-    """
+    """Init the build.
+
     2 cases
     case 1: ipywidgets 7, with require
-    case 2: ipywidgets 7, no require
+    case 2: ipywidgets 7, no require.
     """
     require_url = app.config.jupyter_sphinx_require_url
     if require_url:
         app.add_js_file(require_url)
         embed_url = (
-            app.config.jupyter_sphinx_embed_url
-            or ipywidgets.embed.DEFAULT_EMBED_REQUIREJS_URL
+            app.config.jupyter_sphinx_embed_url or ipywidgets.embed.DEFAULT_EMBED_REQUIREJS_URL
         )
     else:
-        embed_url = (
-            app.config.jupyter_sphinx_embed_url
-            or ipywidgets.embed.DEFAULT_EMBED_SCRIPT_URL
-        )
+        embed_url = app.config.jupyter_sphinx_embed_url or ipywidgets.embed.DEFAULT_EMBED_SCRIPT_URL
     if embed_url:
         app.add_js_file(embed_url)
 

--- a/jupyter_sphinx/_version.py
+++ b/jupyter_sphinx/_version.py
@@ -1,7 +1,4 @@
-"""
-store the current version info of the project.
-
-"""
+"""store the current version info of the project."""
 import re
 from typing import List
 

--- a/jupyter_sphinx/ast.py
+++ b/jupyter_sphinx/ast.py
@@ -1,4 +1,4 @@
-"""Manipulating the Sphinx AST with Jupyter objects"""
+"""Manipulating the Sphinx AST with Jupyter objects."""
 
 import json
 import warnings
@@ -34,9 +34,7 @@ def load_content(cell, location, logger):
         env.note_dependency(rel_filename)
         if cell.content:
             logger.warning(
-                'Ignoring inline code in Jupyter cell included from "{}"'.format(
-                    rel_filename
-                ),
+                'Ignoring inline code in Jupyter cell included from "{}"'.format(rel_filename),
                 location=location,
             )
         try:
@@ -60,9 +58,7 @@ def get_highlights(cell, content, location, logger):
         hl_lines = parselinenos(emphasize_linespec, nlines)
         if any(i >= nlines for i in hl_lines):
             logger.warning(
-                "Line number spec is out of range(1-{}): {}".format(
-                    nlines, emphasize_linespec
-                ),
+                "Line number spec is out of range(1-{}): {}".format(nlines, emphasize_linespec),
                 location=location,
             )
         hl_lines = [i + 1 for i in hl_lines if i < nlines]
@@ -78,7 +74,7 @@ class JupyterCell(Directive):
     executed when the directive is parsed, but later during a doctree
     transformation.
 
-    Arguments
+    Arguments:
     ---------
     filename : str (optional)
         If provided, a path to a file containing code.
@@ -166,7 +162,7 @@ class JupyterCell(Directive):
 class CellInput(Directive):
     """Define a code cell to be included verbatim but not executed.
 
-    Arguments
+    Arguments:
     ---------
     filename : str (optional)
         If provided, a path to a file containing code.
@@ -237,7 +233,7 @@ class CellInput(Directive):
 class CellOutput(Directive):
     """Define an output cell to be included verbatim.
 
-    Arguments
+    Arguments:
     ---------
     filename : str (optional)
         If provided, a path to a file containing output.
@@ -323,12 +319,10 @@ class MimeBundleNode(docutils.nodes.container):
         super().__init__("", *children, mimetypes=attributes["mimetypes"])
 
     def render_as(self, visitor):
-        """Determine which node to show based on the visitor"""
+        """Determine which node to show based on the visitor."""
         try:
             # Or should we go to config via the node?
-            priority = visitor.builder.env.app.config[
-                "render_priority_" + visitor.builder.format
-            ]
+            priority = visitor.builder.env.app.config["render_priority_" + visitor.builder.format]
         except (AttributeError, KeyError):
             # Not sure what do to, act as a container and show everything just in case.
             return super()
@@ -367,9 +361,7 @@ class JupyterWidgetViewNode(docutils.nodes.Element):
         super().__init__("", view_spec=attributes["view_spec"])
 
     def html(self):
-        return ipywidgets.embed.widget_view_template.format(
-            view_spec=json.dumps(self["view_spec"])
-        )
+        return ipywidgets.embed.widget_view_template.format(view_spec=json.dumps(self["view_spec"]))
 
 
 class JupyterWidgetStateNode(docutils.nodes.Element):
@@ -414,7 +406,7 @@ def cell_output_to_nodes(outputs, write_stderr, out_dir, thebe_config, inline=Fa
     inline: False
         Whether the nodes will be placed in-line with the text.
 
-    Returns
+    Returns:
     -------
     to_add : list of docutils nodes
         Each output, converted into a docutils node.
@@ -509,9 +501,7 @@ def output2sphinx(data, mime_type, metadata, out_dir, inline=False):
         math_node = math_block
 
     if mime_type == "text/html":
-        return docutils.nodes.raw(
-            text=data, format="html", classes=["output", "text_html"]
-        )
+        return docutils.nodes.raw(text=data, format="html", classes=["output", "text_html"])
     elif mime_type == "text/plain":
         return literal_node(
             text=data,

--- a/jupyter_sphinx/css/jupyter-sphinx.css
+++ b/jupyter_sphinx/css/jupyter-sphinx.css
@@ -23,15 +23,14 @@ After a build, this stylesheet is loaded from ./_static/jupyter-sphinx.css .
 
 */
 
-
 div.jupyter_container {
-    padding: .4em;
-    margin: 0 0 .4em 0;
-    background-color: #FFFF;
-    border: 1px solid #CCC;
-    -moz-box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
-    -webkit-box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
-    box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
+  padding: 0.4em;
+  margin: 0 0 0.4em 0;
+  background-color: #ffff;
+  border: 1px solid #ccc;
+  -moz-box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
+  -webkit-box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
+  box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
 }
 .jupyter_container div.code_cell {
   border: 1px solid #cfcfcf;
@@ -59,8 +58,8 @@ div.jupyter_container div.highlight {
   background-color: #f7f7f7; /* for haiku */
 }
 div.jupyter_container {
-    padding: 0;
-    margin: 0;
+  padding: 0;
+  margin: 0;
 }
 
 /* Prevent alabaster breaking highlight alignment */
@@ -70,10 +69,10 @@ div.jupyter_container .hll {
 }
 
 /* overrides for sphinx_rtd_theme */
-.rst-content .jupyter_container div[class^='highlight'],
-.document .jupyter_container div[class^='highlight'],
+.rst-content .jupyter_container div[class^="highlight"],
+.document .jupyter_container div[class^="highlight"],
 .rst-content .jupyter_container pre.literal-block {
-  border:none;
+  border: none;
   margin: 0;
   padding: 0;
   background: none;
@@ -86,21 +85,21 @@ div.jupyter_container .hll {
   text-align: center;
 }
 .jupyter_container .stderr {
-    background-color: #FCC;
-    border: none;
-    padding: 3px;
+  background-color: #fcc;
+  border: none;
+  padding: 3px;
 }
 .jupyter_container .output {
-    border: none;
+  border: none;
 }
 .jupyter_container div.output pre {
-    background-color: white;
-    background: none;
-    padding: 4px;
-    border: none;
-    box-shadow: none;
-    -webkit-box-shadow: none; /* for nature */
-    -moz-box-shadow: none; /* for nature */
+  background-color: white;
+  background: none;
+  padding: 4px;
+  border: none;
+  box-shadow: none;
+  -webkit-box-shadow: none; /* for nature */
+  -moz-box-shadow: none; /* for nature */
 }
 .jupyter_container .code_cell td.linenos {
   text-align: right;
@@ -114,10 +113,10 @@ div.jupyter_container .hll {
 /* combine sequential jupyter cells,
    by moving sequential ones up higher on y-axis */
 div.jupyter_container + div.jupyter_container {
-    margin: -.5em 0 .4em 0;
+  margin: -0.5em 0 0.4em 0;
 }
 
 /* Fix for sphinx_rtd_theme spacing after jupyter_container #91 */
 .rst-content .jupyter_container {
-    margin: 0 0 24px 0;
+  margin: 0 0 24px 0;
 }

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -186,7 +186,7 @@ class ExecuteJupyterCells(SphinxTransform):
                     if output["output_type"] == "stream" and output["name"] == "stderr"
                 ]
                 if stderr and not node.attributes["stderr"]:
-                    js.logger.warning("Cell printed to stderr:\n{}".format(stderr[0]["text"]))
+                    js.logger.warning(f"Cell printed to stderr:\n{stderr[0]['text']}")
 
             # Insert input/output into placeholders for non-executed cells
             for node, cell in zip(nodes, notebook.cells):

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -65,7 +65,7 @@ from .utils import (
 class JupyterKernel(Directive):
     """Specify a new Jupyter Kernel.
 
-    Arguments
+    Arguments:
     ---------
     kernel_name : str (optional)
         The name of the kernel in which to execute future Jupyter cells, as
@@ -166,16 +166,10 @@ class ExecuteJupyterCells(SphinxTransform):
 
             # Raise error if cells raised exceptions and were not marked as doing so
             for node, cell in zip(nodes, notebook.cells):
-                errors = [
-                    output
-                    for output in cell.outputs
-                    if output["output_type"] == "error"
-                ]
+                errors = [output for output in cell.outputs if output["output_type"] == "error"]
                 allowed_errors = node.attributes.get("raises") or []
                 raises_provided = node.attributes["raises"] is not None
-                if (
-                    raises_provided and not allowed_errors
-                ):  # empty 'raises': suppress all errors
+                if raises_provided and not allowed_errors:  # empty 'raises': suppress all errors
                     pass
                 elif errors and not any(e["ename"] in allowed_errors for e in errors):
                     raise ExtensionError(
@@ -192,9 +186,7 @@ class ExecuteJupyterCells(SphinxTransform):
                     if output["output_type"] == "stream" and output["name"] == "stderr"
                 ]
                 if stderr and not node.attributes["stderr"]:
-                    js.logger.warning(
-                        "Cell printed to stderr:\n{}".format(stderr[0]["text"])
-                    )
+                    js.logger.warning("Cell printed to stderr:\n{}".format(stderr[0]["text"]))
 
             # Insert input/output into placeholders for non-executed cells
             for node, cell in zip(nodes, notebook.cells):
@@ -224,9 +216,7 @@ class ExecuteJupyterCells(SphinxTransform):
                 # The literal_block node with the source
                 source = node.children[0].children[0]
                 nlines = source.rawsource.count("\n") + 1
-                show_numbering = (
-                    linenos_config or source["linenos"] or source["linenostart"]
-                )
+                show_numbering = linenos_config or source["linenos"] or source["linenostart"]
 
                 if show_numbering:
                     source["linenos"] = True
@@ -251,9 +241,7 @@ class ExecuteJupyterCells(SphinxTransform):
             # Write certain cell outputs (e.g. images) to separate files, and
             # modify the metadata of the associated cells in 'notebook' to
             # include the path to the output file.
-            write_notebook_output(
-                notebook, str(output_dir), file_name, self.env.docname
-            )
+            write_notebook_output(notebook, str(output_dir), file_name, self.env.docname)
 
             try:
                 cm_language = notebook.metadata.language_info.codemirror_mode.name

--- a/jupyter_sphinx/thebelab.py
+++ b/jupyter_sphinx/thebelab.py
@@ -9,7 +9,7 @@ import jupyter_sphinx as js
 
 
 class ThebeSourceNode(docutils.nodes.container):
-    """Container that holds the cell source when thebelab is enabled"""
+    """Container that holds the cell source when thebelab is enabled."""
 
     def __init__(self, rawsource="", *children, **attributes):
         super().__init__("", **attributes)
@@ -30,7 +30,7 @@ class ThebeSourceNode(docutils.nodes.container):
 
 
 class ThebeOutputNode(docutils.nodes.container):
-    """Container that holds all the output nodes when thebelab is enabled"""
+    """Container that holds all the output nodes when thebelab is enabled."""
 
     def visit_html(self):
         return '<div class="thebelab-output" data-output="true">'
@@ -40,7 +40,7 @@ class ThebeOutputNode(docutils.nodes.container):
 
 
 class ThebeButtonNode(docutils.nodes.Element):
-    """Appended to the doctree by the ThebeButton directive
+    """Appended to the doctree by the ThebeButton directive.
 
     Renders as a button to enable thebelab on the page.
 
@@ -61,9 +61,9 @@ class ThebeButtonNode(docutils.nodes.Element):
 
 
 class ThebeButton(Directive):
-    """Specify a button to activate thebelab on the page
+    """Specify a button to activate thebelab on the page.
 
-    Arguments
+    Arguments:
     ---------
     text : str (optional)
         If provided, the button text to display
@@ -83,7 +83,7 @@ class ThebeButton(Directive):
 
 
 def add_thebelab_library(doctree, env):
-    """Adds the thebelab configuration and library to the doctree"""
+    """Adds the thebelab configuration and library to the doctree."""
     thebe_config = env.config.jupyter_sphinx_thebelab_config
     if isinstance(thebe_config, dict):
         pass
@@ -101,14 +101,11 @@ def add_thebelab_library(doctree, env):
         try:
             thebe_config = json.loads(filename.read_text())
         except ValueError:
-            js.logger.warning(
-                "The supplied thebelab configuration file is not in JSON format."
-            )
+            js.logger.warning("The supplied thebelab configuration file is not in JSON format.")
             return
     else:
         js.logger.warning(
-            "The supplied thebelab configuration should be either"
-            " a filename or a dictionary."
+            "The supplied thebelab configuration should be either" " a filename or a dictionary."
         )
         return
 

--- a/jupyter_sphinx/thebelab/thebelab-helper.js
+++ b/jupyter_sphinx/thebelab/thebelab-helper.js
@@ -1,24 +1,25 @@
 function initThebelab() {
-    let activateButton = document.getElementById("thebelab-activate-button");
-    if (activateButton.classList.contains('thebelab-active')) {
-        return;
-    }
+  let activateButton = document.getElementById("thebelab-activate-button");
+  if (activateButton.classList.contains("thebelab-active")) {
+    return;
+  }
 
-    // Place all outputs below the source where this was not the case
-    // to make them recognizable by thebelab
-    let codeBelows = document.getElementsByClassName('thebelab-below');
-    for(var i = 0; i < codeBelows.length; i++) {
-        let prev = codeBelows[i]
-        // Find previous sibling element, compatible with IE8
-        do prev = prev.previousSibling; while(prev && prev.nodeType !== 1);
-        swapSibling(prev, codeBelows[i])
-    }
+  // Place all outputs below the source where this was not the case
+  // to make them recognizable by thebelab
+  let codeBelows = document.getElementsByClassName("thebelab-below");
+  for (var i = 0; i < codeBelows.length; i++) {
+    let prev = codeBelows[i];
+    // Find previous sibling element, compatible with IE8
+    do prev = prev.previousSibling;
+    while (prev && prev.nodeType !== 1);
+    swapSibling(prev, codeBelows[i]);
+  }
 
-    thebelab.bootstrap();
-    activateButton.classList.add('thebelab-active')
+  thebelab.bootstrap();
+  activateButton.classList.add("thebelab-active");
 }
 
 function swapSibling(node1, node2) {
-    node1.parentNode.replaceChild(node1, node2);
-    node1.parentNode.insertBefore(node2, node1);
+  node1.parentNode.replaceChild(node1, node2);
+  node1.parentNode.insertBefore(node2, node1);
 }

--- a/jupyter_sphinx/thebelab/thebelab.css
+++ b/jupyter_sphinx/thebelab/thebelab.css
@@ -1,37 +1,37 @@
 .thebelab-cell .thebelab-input pre {
-    z-index: 0;
+  z-index: 0;
 }
 
 .thebelab-hidden {
-    display: none;
+  display: none;
 }
 
 .thebelab-button {
-    position: relative;
-    display: inline-block;
-    box-sizing: border-box;
-    border: none;
-    border-radius: .1rem;
-    padding: 0 2rem;
-    margin: .5rem .1rem;
-    min-width: 64px;
-    height: 1.6rem;
-    vertical-align: middle;
-    text-align: center;
-    font-size: 0.8rem;
-    color: rgba(0, 0, 0, 0.8);
-    background-color: rgba(0, 0, 0, 0.07);
-    overflow: hidden;
-    outline: none;
-    cursor: pointer;
-    transition: background-color 0.2s;
+  position: relative;
+  display: inline-block;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 0.1rem;
+  padding: 0 2rem;
+  margin: 0.5rem 0.1rem;
+  min-width: 64px;
+  height: 1.6rem;
+  vertical-align: middle;
+  text-align: center;
+  font-size: 0.8rem;
+  color: rgba(0, 0, 0, 0.8);
+  background-color: rgba(0, 0, 0, 0.07);
+  overflow: hidden;
+  outline: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
 }
 
 .thebelab-button:hover {
-    background-color: rgba(0, 0, 0, 0.12);
+  background-color: rgba(0, 0, 0, 0.12);
 }
 
 .thebelab-button:active {
-    background-color: rgba(0, 0, 0, 0.15);
-    color: rgba(0, 0, 0, 1)
+  background-color: rgba(0, 0, 0, 0.15);
+  color: rgba(0, 0, 0, 1);
 }

--- a/jupyter_sphinx/utils.py
+++ b/jupyter_sphinx/utils.py
@@ -26,7 +26,6 @@ def blank_nb(kernel_name):
 
 def split_on(pred, it):
     """Split an iterator wherever a predicate is True."""
-
     counter = 0
 
     def count(x):
@@ -58,7 +57,7 @@ def strip_latex_delimiters(source):
 
 
 def default_notebook_names(basename):
-    """Return an iterator yielding notebook names based off 'basename'"""
+    """Return an iterator yielding notebook names based off 'basename'."""
     yield basename
     for i in count(1):
         yield "_".join((basename, str(i)))
@@ -76,9 +75,7 @@ def sphinx_abs_dir(env, *paths):
     # output_directory / jupyter_execute / path relative to source directory
     # Sphinx expects download links relative to source file or relative to
     # source dir and prepended with '/'. We use the latter option.
-    out_path = (
-        output_directory(env) / Path(env.docname).parent / Path(*paths)
-    ).resolve()
+    out_path = (output_directory(env) / Path(env.docname).parent / Path(*paths)).resolve()
 
     if os.name == "nt":
         # Can't get relative path between drives on Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,5 +103,27 @@ filterwarnings = [
   "module:datetime.datetime.utc:DeprecationWarning"
 ]
 
-[tool.repo-review]
-ignore = ["GH102", "MY100", "RF001", "PY007", "GH103", "PC140"]
+[tool.ruff]
+ignore-init-module-imports = true
+fix = true
+select = ["E", "F", "W", "I", "D", "RUF"]
+ignore = [
+  "E501",  # line too long | Black take care of it
+  "W605",  # invalid escape sequence | we escape specific characters for sphinx
+  "D212", # Multi-line docstring | we use a different convention, too late
+  "D101", # Missing docstring in public class | we use a different convention, too late
+]
+
+[tool.ruff.flake8-quotes]
+docstring-quotes = "double"
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.black]
+line-length = 100
+
+[tool.doc8]
+ignore = [
+  "D001" # we follow a 1 line = 1 paragraph style
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,9 +106,13 @@ fix = true
 select = ["E", "F", "W", "I", "D", "RUF"]
 ignore = [
   "E501",  # line too long | Black take care of it
-  "W605",  # invalid escape sequence | we escape specific characters for sphinx
-  "D212", # Multi-line docstring | we use a different convention, too late
-  "D101", # Missing docstring in public class | we use a different convention, too late
+  "D212", # Multi-line docstring
+  "D100", # Missing docstring in public module
+  "D101", # Missing docstring in public class
+  "D102", # Missing docstring in public method
+  "D103", # Missing docstring in public function
+  "D105", # Missing docstring in magic method
+  "D107", # Missing docstring in `__init__`
 ]
 
 [tool.ruff.flake8-quotes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,10 +71,7 @@ include = [
 detached = true
 dependencies = ["pre-commit"]
 [tool.hatch.envs.lint.scripts]
-build = [
-  "pre-commit run --all-files ruff",
-  "pre-commit run --all-files ruff-format",
-]
+build = "pre-commit run --all-files"
 
 [tool.hatch.envs.doc]
 features = ["doc"]

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -215,11 +215,8 @@ def test_continue_linenos_conf_option(doctree):
         3 + 3
 
     """
-
-    tree = doctree(
-        source,
-        config="jupyter_sphinx_linenos = True\n" "jupyter_sphinx_continue_linenos = True",
-    )
+    config = ["jupyter_sphinx_linenos = True", "jupyter_sphinx_continue_linenos = True"]
+    tree = doctree(source, config="\n".join(config))
 
     cell0, cell1 = tree.findall(JupyterCellNode)
     (cellinput0, celloutput0) = cell0.children
@@ -246,10 +243,8 @@ def test_continue_linenos_conf_option(doctree):
         3 + 3
 
     """
-    tree = doctree(
-        source,
-        config="jupyter_sphinx_linenos = True\n" "jupyter_sphinx_continue_linenos = True",
-    )
+    config = ["jupyter_sphinx_linenos = True", "jupyter_sphinx_continue_linenos = True"]
+    tree = doctree(source, config="\n".join(config))
     cell0, cell1 = tree.findall(JupyterCellNode)
     (cellinput0, celloutput0) = cell0.children
     (cellinput1, celloutput1) = cell1.children

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -30,7 +30,6 @@ from jupyter_sphinx.ast import (
 )
 from jupyter_sphinx.thebelab import ThebeButtonNode, ThebeOutputNode, ThebeSourceNode
 
-
 if os.name == "nt":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
@@ -219,8 +218,7 @@ def test_continue_linenos_conf_option(doctree):
 
     tree = doctree(
         source,
-        config="jupyter_sphinx_linenos = True\n"
-        "jupyter_sphinx_continue_linenos = True",
+        config="jupyter_sphinx_linenos = True\n" "jupyter_sphinx_continue_linenos = True",
     )
 
     cell0, cell1 = tree.findall(JupyterCellNode)
@@ -250,8 +248,7 @@ def test_continue_linenos_conf_option(doctree):
     """
     tree = doctree(
         source,
-        config="jupyter_sphinx_linenos = True\n"
-        "jupyter_sphinx_continue_linenos = True",
+        config="jupyter_sphinx_linenos = True\n" "jupyter_sphinx_continue_linenos = True",
     )
     cell0, cell1 = tree.findall(JupyterCellNode)
     (cellinput0, celloutput0) = cell0.children


### PR DESCRIPTION
As mentioned in #237, I updated the list of pre-commit to something more comfortable. 

The new list is more restricted and cover pretty much the same things as many were overlapping: 
- black for the python file linting (I just aligned the line length to ruff at 100 characters) 
- prettier for anything else (json and yaml schema are tested as well for parsing purposes) 
- nbstripout because we have notebooks
- doc8 (maybe not the best choice but the only one I know for Sphinx checks) 
- ruff, the ligthning fast swiss army knife PEP checker

I also change the lint hatch session so it run the exact same thing as the one in the test suit.

I was forced to add some ignore in ruff for documentation issues. 