### PR TITLE
Update Release Procedure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ jobs:
     needs: [tests]
     name: Publish to PyPi
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -27,6 +30,3 @@ jobs:
         run: python -m build
       - name: Publish
         uses: pypa/gh-action-pypi-publish@v1.8.14
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_KEY }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ To cut a new Jupyter Sphinx release, follow these steps:
 
 - [Create a new Github Release](https://github.com/jupyter/jupyter-sphinx/releases/new).
   The target should be **main**, the tag and the title should be the version number,
-  e.g. `v0.2.3`. Note that this requires admin permissions on the repository.
+  e.g. `v0.2.3`. Note that this requires "Maintain" permissions on the repository.
 
 - Creating the release in GitHub will push a tag commit to the repository, which will
   trigger [a GitHub action](https://github.com/jupyter/jupyter-sphinx/blob/main/.github/workflows/artifacts.yml)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,22 +7,18 @@ To cut a new Jupyter Sphinx release, follow these steps:
 
 - Ensure that all tests are passing on master.
 
-- In [`_version.py`](https://github.com/jupyter/jupyter-sphinx/blob/main/jupyter_sphinx/_version.py),
-  update the version number:
+- Create a pull request to bump the version:
 
-  ```python
-  __version__ = "0.2.3"
-  ```
+  - In [`_version.py`](https://github.com/jupyter/jupyter-sphinx/blob/main/jupyter_sphinx/_version.py),
+    update the version number:
 
-- Make a release commit and push to main
+    ```python
+    __version__ = "0.2.3"
+    ```
 
-  ```
-  git add jupyter_sphinx/_version.py
-  git commit -m "RLS: 0.2.3"
-  git push upstream main
-  ```
+- Merge the pull request.
 
-- [Create a new github release](https://github.com/jupyter/jupyter-sphinx/releases/new).
+- [Create a new Github Release](https://github.com/jupyter/jupyter-sphinx/releases/new).
   The target should be **main**, the tag and the title should be the version number,
   e.g. `v0.2.3`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@ PyPI when a GitHub release is added.
 
 To cut a new Jupyter Sphinx release, follow these steps:
 
-- Ensure that all tests are passing on master.
+- Ensure that all tests are passing on main.
 
 - Create a pull request to bump the version:
 
@@ -20,7 +20,7 @@ To cut a new Jupyter Sphinx release, follow these steps:
 
 - [Create a new Github Release](https://github.com/jupyter/jupyter-sphinx/releases/new).
   The target should be **main**, the tag and the title should be the version number,
-  e.g. `v0.2.3`.
+  e.g. `v0.2.3`. Note that this requires admin permissions on the repository.
 
 - Creating the release in GitHub will push a tag commit to the repository, which will
   trigger [a GitHub action](https://github.com/jupyter/jupyter-sphinx/blob/main/.github/workflows/artifacts.yml)


### PR DESCRIPTION
- Use PyPI trusted publishing (already set up)
- Update release instructions to account for branch and tag Ruleset protections