### PR TITLE
Minor documentation copyedit

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Jupyter Sphinx Extension
    options
    changelog <https://github.com/jupyter/jupyter-sphinx/releases>
 
-Jupyter-sphinx is a Sphinx extension that executes embedded code in a Jupyter kernel, and embeds outputs of that code in the document. It has support for rich output such as images, Latex math and even javascript widgets, and it allows to enable `thebelab <https://thebelab.readthedocs.io/>`_ for live code execution with minimal effort.
+Jupyter-sphinx is a Sphinx extension that executes embedded code in a Jupyter kernel and embeds the outputs of that code in the document. It has support for rich output such as images, Latex math and even javascript widgets, and it allows enabling `thebe <https://thebe.readthedocs.io/>`_ for live code execution with minimal effort.
 
 .. code-block:: rst
 
@@ -43,4 +43,4 @@ Jupyter-sphinx is a Sphinx extension that executes embedded code in a Jupyter ke
 
 .. seealso::
 
-    Other extensions exist to display output of IPyhton cells in a Sphinx documentation. If you want to execute entire notebooks you can consider using `nbsphinx <https://nbsphinx.readthedocs.io>`__ or `myst-nb <https://myst-nb.readthedocs.io/>`__. For in-page live execution consider using `sphinx-thebe <https://sphinx-thebe.readthedocs.io/>`__ or `jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io/>`__. For users that don't need to rely on a jupyter kernel the lightweigth `IPython sphinx directive <https://ipython.readthedocs.io/en/stable/sphinxext.html#ipython-sphinx-directive>`__ can be used but remember it will only be able to display text outputs.
+    Other extensions exist to display the output of IPython cells in Sphinx documentation. If you want to execute entire notebooks you can consider using `nbsphinx <https://nbsphinx.readthedocs.io>`__ or `myst-nb <https://myst-nb.readthedocs.io/>`__. For in-page live execution consider using `sphinx-thebe <https://sphinx-thebe.readthedocs.io/>`__ or `jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io/>`__. For users that don't need to rely on a jupyter kernel the lightweight `IPython sphinx directive <https://ipython.readthedocs.io/en/stable/sphinxext.html#ipython-sphinx-directive>`__ can be used but remember it will only be able to display text outputs.


### PR DESCRIPTION
Three small documentation changes to `docs/index.rst`:

- [x] Fix two typos
- [x] Fix three misused articles (`the` and `a`)
- [x] Change tense of verb (`to enable` -> `enabling`)
- [x] More controversial: Update the very first reference to `thebelab` to `thebe` and update the readthedocs link to point at the newer URL.

Happy to strip the thebelab change if you want to merge the typo fixes but aren't ready to update references to thebelab.

My apologies if this PR is too small for this project, I just noticed a few errors and figured I'd ship a quick copyedit.